### PR TITLE
docs(releases): add release blog post for 0.5.63

### DIFF
--- a/docs/releases/2026-07-28-release-0-5-63.md
+++ b/docs/releases/2026-07-28-release-0-5-63.md
@@ -1,0 +1,68 @@
+---
+slug: release-0.5.63
+title: "Release 0.5.63 — Secret Sharing Team Picker Fix"
+date: 2026-07-28
+authors: [sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-07-28
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.63`
+> Previous release: 0.5.62
+
+## Highlights
+
+0.5.63 is a small fix for the credential sharing panel: the team picker was querying an admin-only endpoint and showing "No teams available" for regular users, even when they belonged to a team they could share with.
+
+<!-- truncate -->
+
+## Bug Fixes
+
+- **credentials**: the secret sharing panel now loads share candidates from the caller-scoped teams endpoint instead of an admin-only one, so regular users see the teams they actually belong to instead of an empty picker. ([#2312](https://github.com/cnoe-io/ai-platform-engineering/pull/2312))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.62.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.5.62 → 0.5.63
+
+### Overview
+
+Drop-in upgrade — no `values.yaml` edits required.
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.62 and 0.5.63. Drop-in upgrade.
+
+### Upgrade Runbook
+
+#### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.63 \
+  -f your-values.yaml
+```
+
+#### 2. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If non-admin users previously saw "No teams available" when trying to share a credential, confirm their team now appears in the picker.
+
+### Personal Impact Analysis
+
+No `values.yaml` changes required.
+
+### Full Values Diff
+
+No diff — `values.yaml` is identical between 0.5.62 and 0.5.63.

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.62 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.63 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {


### PR DESCRIPTION
## Description

Adds the release blog post for `0.5.63` (tagged 2026-07-28) and bumps the homepage Helm quickstart version string to match.

- `docs/releases/2026-07-28-release-0-5-63.md` — secret sharing team picker fix ([#2312](https://github.com/cnoe-io/ai-platform-engineering/pull/2312)): the panel queried an admin-only teams endpoint, so regular users saw "No teams available" even when they belonged to a shareable team.
- `docs/src/pages/index.tsx` — Helm quickstart `--version` bumped `0.5.62` to `0.5.63`.
- No Helm values changes between 0.5.62 and 0.5.63 (drop-in upgrade).
- `CHANGELOG.md` already has a correct `## 0.5.63` heading from this bump (no manual fix needed this time).

## Type of Change

- [x] Documentation

## Checklist

- [x] I have read the contributing guidelines
- [x] Functionality is documented
- [x] All code style checks pass
