### PR TITLE
fix(dynamic-agents): coerce GridFS namespace components to str before Mongo queries

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/gridfs_store.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/gridfs_store.py
@@ -26,6 +26,17 @@ from pymongo.errors import OperationFailure
 logger = logging.getLogger(__name__)
 
 
+def _coerce_namespace(namespace: Iterable[object]) -> list[str]:
+    """Coerce namespace components to plain strings before use in a Mongo query.
+
+    Callers ultimately source namespace components from external input (e.g.
+    request path/query params). Forcing each component to `str` before it
+    reaches a query dict prevents NoSQL operator injection ($ne, $where, ...)
+    if a component were ever an unvalidated dict instead of a string.
+    """
+    return [str(component) for component in namespace]
+
+
 class MongoDBGridFSStore(BaseStore):
     """BaseStore implementation backed by MongoDB GridFS.
 
@@ -71,7 +82,7 @@ class MongoDBGridFSStore(BaseStore):
         return await asyncio.to_thread(self.batch, ops)
 
     def _handle_get(self, op: GetOp) -> Item | None:
-        namespace = list(op.namespace)
+        namespace = _coerce_namespace(op.namespace)
         logger.debug(f"[gridfs] GET namespace={op.namespace} key={op.key}")
         doc = self._files_collection.find_one({"metadata.namespace": namespace, "metadata.key": op.key})
         if doc is None:
@@ -91,7 +102,7 @@ class MongoDBGridFSStore(BaseStore):
         )
 
     def _handle_put(self, op: PutOp) -> None:
-        namespace = list(op.namespace)
+        namespace = _coerce_namespace(op.namespace)
         # Delete existing file(s) with same namespace+key
         for doc in self._files_collection.find({"metadata.namespace": namespace, "metadata.key": op.key}):
             self._fs.delete(doc["_id"])
@@ -113,7 +124,7 @@ class MongoDBGridFSStore(BaseStore):
         logger.debug(f"[gridfs] PUT namespace={op.namespace} key={op.key} size={len(content)}")
 
     def _handle_search(self, op: SearchOp) -> list[SearchItem]:
-        namespace_prefix = list(op.namespace_prefix)
+        namespace_prefix = _coerce_namespace(op.namespace_prefix)
         logger.debug(f"[gridfs] SEARCH namespace_prefix={op.namespace_prefix} limit={op.limit} offset={op.offset}")
         prefix_len = len(namespace_prefix)
 
@@ -177,7 +188,7 @@ class MongoDBGridFSStore(BaseStore):
                 if cond.match_type == "prefix":
                     for i, component in enumerate(cond.path):
                         if component != "*":
-                            match_filters.append({f"metadata.namespace.{i}": component})
+                            match_filters.append({f"metadata.namespace.{i}": str(component)})
                 elif cond.match_type == "suffix":
                     # Suffix matching requires post-filtering
                     pass
@@ -208,7 +219,7 @@ class MongoDBGridFSStore(BaseStore):
 
     def delete_by_namespace(self, namespace: tuple[str, ...]) -> int:
         """Delete all files in a namespace. Returns count of deleted files."""
-        namespace_list = list(namespace)
+        namespace_list = _coerce_namespace(namespace)
         count = 0
         for doc in self._files_collection.find({"metadata.namespace": namespace_list}):
             self._fs.delete(doc["_id"])
@@ -217,7 +228,7 @@ class MongoDBGridFSStore(BaseStore):
 
     def delete_by_key_prefix(self, namespace: tuple[str, ...], prefix: str) -> int:
         """Delete all files in a namespace whose key starts with prefix."""
-        namespace_list = list(namespace)
+        namespace_list = _coerce_namespace(namespace)
         query = {
             "metadata.namespace": namespace_list,
             "metadata.key": {"$regex": f"^{re.escape(prefix)}"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.63-dev.2"
+version = "0.5.63-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.63.dev2"
+version = "0.5.63.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Fixes CodeQL alert [#19820](https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/19820) — a high-severity NoSQL injection finding (`py/nosql-injection`) at `gridfs_store.py:213` in `delete_by_namespace`.

The namespace components used to build MongoDB `find()` filters in `MongoDBGridFSStore` ultimately trace back to request-sourced input (the `fs_namespace` query param on the `/files/*` routes). The `/files/namespace` route already validates each element is a string via `_parse_namespace`, but that guarantee isn't visible to CodeQL's dataflow analysis, and nothing enforced it at the point the query dict is actually built.

## Fix

Added a `_coerce_namespace()` helper that forces every namespace component to `str` right before it reaches a query, and applied it at every construction site in the file: `_handle_get`, `_handle_put`, `_handle_search`, `delete_by_namespace`, `delete_by_key_prefix`, plus the prefix-match filter in `_handle_list_namespaces`. This closes the injection class at the sink regardless of what validation exists upstream — a dict value just gets stringified into a harmless literal instead of being usable as a Mongo operator.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `uv run ruff check src/dynamic_agents/services/gridfs_store.py` — clean
- `uv run pytest -q -k "gridfs or files or namespace"` — 18 passed
- `uv run pytest -q` (full dynamic_agents suite) — same pre-existing unrelated failure on `main` (`test_mongo_credential_sources_self_heal.py`), nothing newly broken

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in this description
- [x] All code style checks pass
- [x] Relevant new and existing tests pass
