### PR TITLE
fix(ci): skip PR version-bump auto-commit for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -55,6 +55,18 @@ jobs:
               return;
             }
 
+            // Dependabot-triggered pull_request runs are on a branch of this
+            // same repo (not a fork), but GitHub Actions still denies them
+            // repo secrets by default — same CI_BUILD_APP_ID/PRIVATE_KEY gap
+            // as the fork case above, just a different trigger for it.
+            const isDependabot = context.actor === 'dependabot[bot]' || pr.user?.login === 'dependabot[bot]';
+            if (isDependabot) {
+              core.setOutput('should_run', 'false');
+              core.setOutput('reason', 'Dependabot PR — GitHub Actions denies repo secrets to Dependabot-triggered pull_request runs; version bump is applied after merge');
+              core.notice('should_run=false: Dependabot PR — skipping version-bump auto-commit; auto-tag.yml finalizes the version on push to main.');
+              return;
+            }
+
             const supportedBase = pr.base.ref === 'main' || pr.base.ref.startsWith('release/');
             if (!supportedBase) {
               core.setOutput('should_run', 'false');


### PR DESCRIPTION
## Description

`chore(deps)` PR #2320 (Dependabot bumping `pyasn1`/`pypdf`) fails CI on the "Bump version files on PR" check with:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

## Root cause

`pr-version-bump.yml`'s `eligibility` job already skips this auto-commit job for fork PRs, because GitHub Actions denies repo secrets to fork-triggered `pull_request` runs (PR #2281 fixed that case). Dependabot PRs branch off `dependabot/...` on this same repo, so `pr.head.repo.full_name === owner/repo` and the fork check doesn't catch them — but GitHub Actions applies the exact same secret-denial policy to Dependabot-triggered `pull_request` runs. `secrets.CI_BUILD_APP_ID` resolves to an empty string, and `actions/create-github-app-token` hard-fails instead of the job being skipped.

## Fix

Add the same actor check already used for the fork case: skip the version-bump job cleanly when `github.actor == 'dependabot[bot]'`, with an equivalent notice. `auto-tag.yml` still finalizes the version on push to `main` regardless of what's on the PR branch, so nothing is lost by skipping.

## Type of Change

- [x] Bugfix

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- Extracted and syntax-checked the embedded `github-script` JS (braces/parens balanced, no new syntax errors)
- `actionlint` — no new findings introduced; all existing findings are pre-existing and unrelated to this change

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (PR #2320 is the trigger)
- [x] Functionality is documented in this description
- [x] All code style checks pass
