### PR TITLE
fix(dynamic-agents): send text-family documents as A

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, NamedTuple
 from uuid import uuid4
 
+from cnoe_agent_utils.llm_factory import resolve_bedrock_client
 from cnoe_agent_utils.tracing import TracingManager
 from deepagents import create_deep_agent
 from deepagents.backends.state import StateBackend
@@ -76,7 +77,12 @@ from dynamic_agents.services.mcp_client import (
     resolve_mcp_connections_credential_refs,
     wrap_tools_with_error_handling,
 )
-from dynamic_agents.services.middleware import ToolResultInvariantMiddleware, build_middleware
+from dynamic_agents.services.middleware import (
+    TEXT_DOCUMENT_MIME_TYPES,
+    ToolResultInvariantMiddleware,
+    anthropic_text_document_block,
+    build_middleware,
+)
 from dynamic_agents.services.model_capabilities import (
     ModelCapabilities,
     get_model_capabilities,
@@ -268,6 +274,12 @@ _SUPPORTED_DOC_MIME_TYPES = frozenset(
         "text/markdown",
     }
 )
+# Document types only the Anthropic Messages API client can ingest. Bedrock
+# Converse has no document format for XML (``_mime_type_to_format`` raises), but
+# the Anthropic client accepts it as a *text* document source. So these are kept
+# only when the resolved client is ``anthropic`` (see ``_build_user_content``);
+# on Converse/legacy they're skipped as unsupported rather than breaking the turn.
+_ANTHROPIC_ONLY_DOC_MIME_TYPES = frozenset({"text/xml", "application/xml"})
 
 
 # Reasons a file was dropped from the user turn, in machine-readable form so
@@ -389,6 +401,25 @@ def _estimated_bytes(f: "InputFile") -> int:
     return n * 3 // 4
 
 
+def _inline_document_block(
+    block: dict[str, Any], f: "InputFile", needs_text_source: bool
+) -> dict[str, Any]:
+    """Attach inline file bytes to ``block`` in the shape the adapter expects.
+
+    For most files that's ``base64``. For text-family documents on the Anthropic
+    client (``needs_text_source``) it's a text source carrying the decoded UTF-8
+    text, because Anthropic rejects non-PDF base64 document sources.
+    """
+    if needs_text_source and f.data:
+        try:
+            text = base64.b64decode(f.data).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            text = base64.b64decode(f.data).decode("utf-8", errors="replace")
+        return anthropic_text_document_block(block, text)
+    block["base64"] = f.data
+    return block
+
+
 def _build_user_content(
     message: str,
     files: "list[InputFile] | None",
@@ -435,6 +466,11 @@ def _build_user_content(
         return message, []
 
     caps = capabilities or ModelCapabilities()  # permissive default
+    # The Anthropic Messages API client needs text-family docs as text sources
+    # (base64 doc sources there are PDF-only) and is the only client that can
+    # take XML at all. Resolve once; None model_id (unit tests) means "not
+    # anthropic", preserving the legacy inline-base64 shape.
+    is_anthropic = bool(model_id) and resolve_bedrock_client(model_id) == "anthropic"
     blocks: list[dict[str, Any]] = [{"type": "text", "text": message}]
     skipped: list[SkippedFile] = []
     kept_files = 0
@@ -467,6 +503,10 @@ def _build_user_content(
             block_type = "image"
         elif f.mime_type in _SUPPORTED_DOC_MIME_TYPES:
             block_type = "file"
+        elif is_anthropic and f.mime_type in _ANTHROPIC_ONLY_DOC_MIME_TYPES:
+            # XML: no Bedrock Converse document format exists, but the Anthropic
+            # client reads it as a text document source.
+            block_type = "file"
         else:
             logger.warning(
                 f"[stream] Skipping file with unsupported type '{f.mime_type}' "
@@ -487,13 +527,21 @@ def _build_user_content(
             continue
 
         block: dict[str, Any] = {"type": block_type, "mime_type": f.mime_type}
+        # Text-family documents on the Anthropic client can't ride as base64
+        # document sources (PDF-only there) — they need a text source carrying
+        # the decoded content. When a store is configured the shaping happens at
+        # rehydration (bytes stay out of the checkpoint); here we handle the
+        # inline paths (no store, or a store put that fell back to inline).
+        needs_text_source = (
+            is_anthropic and block_type == "file" and f.mime_type in TEXT_DOCUMENT_MIME_TYPES
+        )
         if store is not None and f.data:
             # Reference form: upload bytes once (content-addressed) and persist
-            # only the key. The rehydration middleware turns this back into an
-            # inline base64 block before the model call — bytes never enter the
-            # checkpoint. On any store failure, fall back to inline base64 so a
-            # storage hiccup degrades to today's behavior instead of dropping
-            # the file.
+            # only the key. The rehydration middleware turns this back into the
+            # right inline block (base64, or a text source for text docs on the
+            # Anthropic client) before the model call — bytes never enter the
+            # checkpoint. On any store failure, fall back to inline so a storage
+            # hiccup degrades to today's behavior instead of dropping the file.
             try:
                 raw = base64.b64decode(f.data)
                 key = store.put(raw, content_type=f.mime_type)
@@ -501,14 +549,15 @@ def _build_user_content(
             except Exception as exc:  # noqa: BLE001 — never fail the turn on storage
                 logger.warning(
                     f"[stream] Attachment store put failed for '{f.name!r}' "
-                    f"({f.mime_type}); falling back to inline base64: {exc}"
+                    f"({f.mime_type}); falling back to inline: {exc}"
                 )
-                block["base64"] = f.data
+                block = _inline_document_block(block, f, needs_text_source)
         elif f.data:
-            block["base64"] = f.data
+            block = _inline_document_block(block, f, needs_text_source)
         else:
             block["url"] = f.uri
         # Document blocks carry a filename; the adapter warns without one.
+        # (Text-source blocks keep it too — harmless and preserves provenance.)
         if block_type == "file" and f.name:
             block["name"] = f.name
         blocks.append(block)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -50,6 +50,62 @@ from dynamic_agents.models import FeaturesConfig, MiddlewareEntry
 logger = logging.getLogger(__name__)
 
 
+# Text-family document MIME types. These are UTF-8 text, and on the
+# ``ChatAnthropicBedrock`` (Anthropic Messages API) client Bedrock rejects them
+# as base64 document sources — that source only accepts ``application/pdf``
+# (error: ``document.source.base64.media_type: Input should be
+# 'application/pdf'``). They must be sent as a *text* document source instead
+# (``source_type="text"`` with the decoded text and ``media_type="text/plain"``).
+# The Converse/legacy clients, by contrast, accept these as base64 documents, so
+# the text-source rewrite is gated on the resolved Anthropic client.
+#
+# Kept here (rather than beside ``_SUPPORTED_DOC_MIME_TYPES`` in agent_runtime)
+# so both the write path (agent_runtime imports this) and the rehydration path
+# (this module) share one definition without an import cycle.
+TEXT_DOCUMENT_MIME_TYPES = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "text/html",
+        "text/xml",
+        "application/xml",
+    }
+)
+
+
+def anthropic_text_document_block(
+    block: dict[str, Any], decoded_text: str
+) -> dict[str, Any]:
+    """Rewrite a document ``block`` into a LangChain v1 ``text-plain`` block.
+
+    langchain-core normalizes message content to v1 content blocks before the
+    Anthropic adapter runs. The adapter renders a ``text-plain`` block into the
+    ``{"type": "document", "source": {"type": "text", ...}}`` shape the Anthropic
+    Messages API requires for text-family documents (a base64 document source is
+    PDF-only there).
+
+    Emitting the v1-native ``text-plain`` block directly is deliberate: a legacy
+    ``{"type": "file", "source_type": "text"}`` block would instead be routed
+    through langchain-core's v0->v1 converter, which reads the text content from
+    the ``url`` key (``KeyError: 'url'`` if it's carried anywhere else) and wraps
+    stray keys in ``extras``. ``text-plain`` bypasses that converter entirely.
+
+    ``mime_type`` is forced to ``text/plain`` because Anthropic's text document
+    source only accepts that media type — the original type (e.g. ``text/xml``)
+    is still fully visible to the model as the text content, tags and all.
+    """
+    rebuilt = {
+        k: v
+        for k, v in block.items()
+        if k not in ("base64", "source", "url", "source_type")
+    }
+    rebuilt["type"] = "text-plain"
+    rebuilt["mime_type"] = "text/plain"
+    rebuilt["text"] = decoded_text
+    return rebuilt
+
+
 class ToolResultInvariantMiddleware(AgentMiddleware):
     """Patch tool calls that lost their results before each model request."""
 
@@ -172,12 +228,17 @@ class AttachmentRehydrationMiddleware(AgentMiddleware):
         self,
         store: Any,
         *,
+        model_id: str = "unknown",
         cache_max_entries: int = 32,
     ) -> None:
         super().__init__()
         self._store = store
         self._cache_max_entries = cache_max_entries
         self._lru: "OrderedDict[str, bytes]" = OrderedDict()
+        # Text-family documents must be shaped as text sources (not base64) on
+        # the Anthropic Messages API client. Resolve once — the client doesn't
+        # change over the agent's lifetime.
+        self._is_anthropic = resolve_bedrock_client(model_id) == "anthropic"
 
     def _fetch(self, key: str) -> bytes:
         cached = self._lru.get(key)
@@ -203,15 +264,25 @@ class AttachmentRehydrationMiddleware(AgentMiddleware):
         if not (isinstance(source, Mapping) and source.get("store_key")):
             return dict(block)
         key = source["store_key"]
-        rebuilt = {k: v for k, v in block.items() if k != "source"}
         try:
             raw = self._fetch(key)
-            rebuilt["base64"] = base64.b64encode(raw).decode("ascii")
         except Exception as exc:  # noqa: BLE001 — a bad blob shouldn't sink the turn
             logger.warning(
                 "[attachment] Rehydration failed for store_key=%s: %s", key, exc
             )
             return dict(block)
+        # Text-family documents on the Anthropic client must ride as a text
+        # source; base64 document sources there are PDF-only. Everything else
+        # (images, PDF, Office docs, and all docs on Converse/legacy) stays
+        # inline base64.
+        if self._is_anthropic and block.get("mime_type") in TEXT_DOCUMENT_MIME_TYPES:
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                text = raw.decode("utf-8", errors="replace")
+            return anthropic_text_document_block(dict(block), text)
+        rebuilt = {k: v for k, v in block.items() if k != "source"}
+        rebuilt["base64"] = base64.b64encode(raw).decode("ascii")
         return rebuilt
 
     def _rehydrate_messages(self, messages: list[BaseMessage]) -> tuple[list[BaseMessage], bool]:
@@ -648,7 +719,7 @@ def build_middleware(
     # added when a store is configured — otherwise attachments ride inline and
     # there is nothing to rehydrate.
     if attachment_store is not None:
-        result.append(AttachmentRehydrationMiddleware(attachment_store))
+        result.append(AttachmentRehydrationMiddleware(attachment_store, model_id=model_id))
 
     # Prompt caching: delegate to the native langchain caching middleware for the
     # resolved Bedrock client. Gated on the Bedrock provider — OpenAI/Gemini cache

--- a/ai_platform_engineering/dynamic_agents/tests/test_attachment_rehydration_middleware.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_attachment_rehydration_middleware.py
@@ -160,6 +160,108 @@ def test_plain_text_messages_pass_through_unchanged(tmp_path):
     assert rebuilt == messages
 
 
+# --- Rehydration: text docs shaped per client (the Bedrock 400 fix) ----------
+
+_ANTHROPIC_MODEL = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+_CONVERSE_MODEL = "us.amazon.nova-pro-v1:0"
+
+
+def test_rehydrate_text_doc_becomes_text_source_on_anthropic(tmp_path):
+    # The dev failure path: S3 store on, Anthropic client. A text/plain doc must
+    # be re-inflated as a text source, not a base64 document source (which
+    # Bedrock rejects: "Input should be 'application/pdf'").
+    store = LocalAttachmentStore(str(tmp_path))
+    key = store.put(b"plain body", content_type="text/plain")
+    mw = AttachmentRehydrationMiddleware(store, model_id=_ANTHROPIC_MODEL)
+
+    msg = _ref_message(key, block_type="file", mime="text/plain")
+    rebuilt, changed = mw._rehydrate_messages([msg])
+
+    assert changed
+    block = rebuilt[0].content[1]
+    # v1-native text-plain block (renders to a document/text source). A legacy
+    # source_type="text" block would be routed through the v0->v1 converter,
+    # which reads the text from ``url`` and raises ``KeyError: 'url'``.
+    assert block["type"] == "text-plain"
+    assert block["mime_type"] == "text/plain"
+    assert block["text"] == "plain body"
+    assert "source_type" not in block
+    assert "base64" not in block and "source" not in block
+
+
+def test_rehydrate_xml_becomes_text_source_on_anthropic(tmp_path):
+    store = LocalAttachmentStore(str(tmp_path))
+    key = store.put(b"<root>x</root>", content_type="text/xml")
+    mw = AttachmentRehydrationMiddleware(store, model_id=_ANTHROPIC_MODEL)
+
+    msg = _ref_message(key, block_type="file", mime="text/xml")
+    rebuilt, _ = mw._rehydrate_messages([msg])
+
+    block = rebuilt[0].content[1]
+    assert block["type"] == "text-plain"
+    assert block["mime_type"] == "text/plain"
+    assert block["text"] == "<root>x</root>"
+    assert "source_type" not in block
+
+
+def test_rehydrate_pdf_stays_base64_on_anthropic(tmp_path):
+    store = LocalAttachmentStore(str(tmp_path))
+    raw = b"%PDF-1.4 body"
+    key = store.put(raw, content_type="application/pdf")
+    mw = AttachmentRehydrationMiddleware(store, model_id=_ANTHROPIC_MODEL)
+
+    msg = _ref_message(key, block_type="file", mime="application/pdf")
+    rebuilt, _ = mw._rehydrate_messages([msg])
+
+    block = rebuilt[0].content[1]
+    assert base64.b64decode(block["base64"]) == raw
+    assert "source_type" not in block
+
+
+def test_rehydrate_text_doc_stays_base64_on_converse(tmp_path):
+    # Converse accepts text docs as base64 — don't rewrite to a text source
+    # (the Converse formatter has no text-source branch and would raise).
+    store = LocalAttachmentStore(str(tmp_path))
+    raw = b"plain body"
+    key = store.put(raw, content_type="text/plain")
+    mw = AttachmentRehydrationMiddleware(store, model_id=_CONVERSE_MODEL)
+
+    msg = _ref_message(key, block_type="file", mime="text/plain")
+    rebuilt, _ = mw._rehydrate_messages([msg])
+
+    block = rebuilt[0].content[1]
+    assert base64.b64decode(block["base64"]) == raw
+    assert "source_type" not in block
+
+
+def test_write_then_rehydrate_roundtrip_text_doc_on_anthropic(tmp_path):
+    # End-to-end store path: _build_user_content stores a reference (no inline
+    # bytes), then the middleware re-inflates it as a text source for Anthropic.
+    store = LocalAttachmentStore(str(tmp_path))
+    raw = b"<events><win/></events>"
+    files = [
+        InputFile(mime_type="text/xml", data=base64.b64encode(raw).decode(), name="win.xml"),
+    ]
+    content, skipped = _build_user_content(
+        "read", files, model_id=_ANTHROPIC_MODEL, store=store
+    )
+    # Write path: reference only, no bytes in the checkpoint.
+    ref_block = content[1]
+    assert ref_block["source"]["store_key"]
+    assert "base64" not in ref_block and "text" not in ref_block
+    assert skipped == []
+
+    mw = AttachmentRehydrationMiddleware(store, model_id=_ANTHROPIC_MODEL)
+    msg = HumanMessage(content=content)
+    rebuilt, changed = mw._rehydrate_messages([msg])
+
+    assert changed
+    block = rebuilt[0].content[1]
+    assert block["type"] == "text-plain"
+    assert block["text"] == raw.decode()
+    assert "source_type" not in block
+
+
 # --- prompt-cache middleware selection ---------------------------------------
 
 

--- a/ai_platform_engineering/dynamic_agents/tests/test_multimodal_user_content.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_multimodal_user_content.py
@@ -11,6 +11,8 @@ can surface a warning to the user.
 
 from __future__ import annotations
 
+import base64
+
 from dynamic_agents.models import InputFile
 from dynamic_agents.services.agent_runtime import (
     SKIP_FILE_TOO_LARGE,
@@ -83,6 +85,131 @@ def test_mixed_image_and_document_both_kept():
     assert len(content) == 3
     assert [b["type"] for b in content] == ["text", "file", "image"]
     assert skipped == []
+
+
+# --- Anthropic text-source shaping (Bedrock rejects non-PDF base64 docs) ------
+
+_ANTHROPIC_MODEL = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+_CONVERSE_MODEL = "us.amazon.nova-pro-v1:0"
+
+
+def test_anthropic_text_doc_sent_as_text_source_not_base64():
+    # On the Anthropic client a text/plain doc as a base64 document source is
+    # rejected ("Input should be 'application/pdf'"). It must go as a text source
+    # carrying the decoded content, with media_type normalized to text/plain.
+    data = base64.b64encode(b"hello world").decode()
+    files = [InputFile(mime_type="text/plain", data=data, name="notes.txt")]
+
+    content, skipped = _build_user_content("read", files, model_id=_ANTHROPIC_MODEL)
+
+    assert isinstance(content, list)
+    block = content[1]
+    # A v1-native ``text-plain`` block: langchain-anthropic renders it to a
+    # document/text source. A legacy ``source_type="text"`` block would instead
+    # be routed through langchain-core's v0->v1 converter, which reads the text
+    # from ``url`` and raises ``KeyError: 'url'`` here.
+    assert block["type"] == "text-plain"
+    assert block["mime_type"] == "text/plain"
+    assert block["text"] == "hello world"
+    assert "source_type" not in block
+    assert "base64" not in block
+    assert skipped == []
+
+
+def test_anthropic_accepts_xml_as_text_source():
+    # XML has no Bedrock document format, but the Anthropic client reads it as a
+    # text source. The original tags survive in the text; media_type is text/plain.
+    data = base64.b64encode(b"<root><a/></root>").decode()
+    files = [InputFile(mime_type="text/xml", data=data, name="win.xml")]
+
+    content, skipped = _build_user_content("parse", files, model_id=_ANTHROPIC_MODEL)
+
+    assert isinstance(content, list)
+    block = content[1]
+    assert block["type"] == "text-plain"
+    assert block["mime_type"] == "text/plain"
+    assert block["text"] == "<root><a/></root>"
+    assert "source_type" not in block
+    assert skipped == []
+
+
+def test_anthropic_pdf_still_rides_as_base64():
+    # PDF is the one document type Anthropic accepts as base64 — leave it alone.
+    files = [InputFile(mime_type="application/pdf", data="cGRm", name="r.pdf")]
+    content, skipped = _build_user_content("summarize", files, model_id=_ANTHROPIC_MODEL)
+
+    block = content[1]
+    assert block["base64"] == "cGRm"
+    assert "source_type" not in block
+    assert skipped == []
+
+
+def test_anthropic_text_block_survives_real_langchain_pipeline():
+    # Regression for the dev failure: a unit test asserting our block shape in
+    # isolation passed, but prod raised ``KeyError: 'url'``. The block we emit is
+    # first run through langchain-core's ``_normalize_messages`` (v0->v1) and then
+    # langchain-anthropic's ``_format_messages`` before it ever reaches Bedrock.
+    # Drive it through both real functions so the contract is verified end-to-end.
+    import importlib.util
+
+    import pytest
+
+    if (
+        importlib.util.find_spec("langchain_core.language_models._utils") is None
+        or importlib.util.find_spec("langchain_anthropic") is None
+    ):
+        pytest.skip("langchain-core/-anthropic not importable in this environment")
+
+    from langchain_anthropic.chat_models import _format_messages  # type: ignore
+    from langchain_core.language_models._utils import _normalize_messages
+    from langchain_core.messages import HumanMessage
+
+    data = base64.b64encode(b"hello world").decode()
+    files = [InputFile(mime_type="text/plain", data=data, name="notes.txt")]
+    content, _ = _build_user_content("read", files, model_id=_ANTHROPIC_MODEL)
+
+    normalized = _normalize_messages([HumanMessage(content=content)])
+    _system, formatted = _format_messages(normalized)
+
+    # The text doc lands as an Anthropic document/text source, not a base64 doc
+    # (which Bedrock rejects with "Input should be 'application/pdf'").
+    doc_blocks = [
+        b
+        for m in formatted
+        for b in (m["content"] if isinstance(m["content"], list) else [])
+        if isinstance(b, dict) and b.get("type") == "document"
+    ]
+    assert doc_blocks, f"no document block produced: {formatted}"
+    source = doc_blocks[0]["source"]
+    assert source["type"] == "text"
+    assert source["media_type"] == "text/plain"
+    assert source["data"] == "hello world"
+
+
+def test_converse_keeps_text_as_base64_and_skips_xml():
+    # Non-anthropic (Converse) client: text docs still ride as base64 (Converse
+    # accepts them), and XML is skipped as unsupported rather than erroring.
+    txt = base64.b64encode(b"plain").decode()
+    files = [
+        InputFile(mime_type="text/plain", data=txt, name="n.txt"),
+        InputFile(mime_type="text/xml", data=base64.b64encode(b"<a/>").decode(), name="w.xml"),
+    ]
+    content, skipped = _build_user_content("x", files, model_id=_CONVERSE_MODEL)
+
+    assert isinstance(content, list)
+    assert content[1] == {"type": "file", "mime_type": "text/plain", "base64": txt, "name": "n.txt"}
+    assert [s.name for s in skipped] == ["w.xml"]
+    assert skipped[0].reason == SKIP_UNSUPPORTED_BY_PROVIDER
+
+
+def test_no_model_id_preserves_legacy_base64_shape():
+    # model_id=None (the unit-test default) must not trigger text-source shaping.
+    data = base64.b64encode(b"legacy").decode()
+    files = [InputFile(mime_type="text/plain", data=data, name="n.txt")]
+    content, _ = _build_user_content("x", files)  # no model_id
+
+    assert content[1]["base64"] == data
+    assert "source_type" not in content[1]
 
 
 def test_unsupported_type_is_skipped_and_degrades_to_string():

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.63 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.64 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.63 -f your-values.yaml'}
+                  {'    --version 0.5.64 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.63 -f your-values.yaml'}
+              {'    --version 0.5.64 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.64"
+version = "0.5.64-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/__tests__/file-attachments.test.ts
+++ b/ui/src/lib/__tests__/file-attachments.test.ts
@@ -29,6 +29,9 @@ describe("MIME allowlist", () => {
     expect(isAcceptedMimeType("image/png")).toBe(true);
     expect(isAcceptedMimeType("application/pdf")).toBe(true);
     expect(isAcceptedMimeType("text/markdown")).toBe(true);
+    // XML: sent to Anthropic models as a text document source.
+    expect(isAcceptedMimeType("text/xml")).toBe(true);
+    expect(isAcceptedMimeType("application/xml")).toBe(true);
   });
 
   it("rejects types the backend would drop", () => {

--- a/ui/src/lib/file-attachments.ts
+++ b/ui/src/lib/file-attachments.ts
@@ -23,7 +23,12 @@ export const ACCEPTED_IMAGE_MIME_TYPES = [
   "image/webp",
 ] as const;
 
-/** Document MIME types the backend maps to document blocks. */
+/**
+ * Document MIME types the backend maps to document blocks. Text-family docs
+ * (txt/md/csv/html/xml) are sent to Anthropic models as text document sources;
+ * xml is Anthropic-only (Bedrock Converse has no xml format), so a non-Anthropic
+ * agent skips it server-side with a warning rather than erroring.
+ */
 export const ACCEPTED_DOC_MIME_TYPES = [
   "application/pdf",
   "text/csv",
@@ -34,6 +39,8 @@ export const ACCEPTED_DOC_MIME_TYPES = [
   "text/html",
   "text/plain",
   "text/markdown",
+  "text/xml",
+  "application/xml",
 ] as const;
 
 /** Every MIME type the composer will accept before upload. */

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.64"
+version = "0.5.64.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Uploaded text-family documents (text/plain, text/markdown, text/csv, text/html) failed on Anthropic Bedrock with a 400: a base64 document source only accepts application/pdf there. XML was additionally rejected at the UI allowlist before it could be sent at all.

Route text-family documents to the model as a text source rather than a base64 document source when the resolved client is Anthropic. The block is emitted as a langchain v1 text-plain content block, which langchain-anthropic renders to the {type: document, source: {type: text, media_type: text/plain, data: ...}} shape the Messages API requires. This is deliberate over a legacy {type: file, source_type: text} block: langchain-core normalizes content to v1 before the adapter runs, and a source_type-bearing block is routed through the v0->v1 converter, which reads the text from the url key and raises KeyError otherwise. Non-Anthropic (Converse) clients keep sending text docs as base64, which they accept.

The original document type (e.g. text/xml) is preserved verbatim in the text content, so the model still sees the full markup. text/xml and application/xml are also added to the UI's accepted document types.

Covered by unit tests for both the write path and the rehydration middleware, plus a regression test that drives a block through the real langchain-core normalize + langchain-anthropic format pipeline end to end.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass