### PR TITLE
fix(slack-bot): route messages with file attachments

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -60,6 +60,9 @@ from utils.slack_admin_api import start_slack_admin_api_server  # noqa: E402
 app = App(token=os.environ.get("SLACK_INTEGRATION_BOT_TOKEN", os.environ.get("SLACK_BOT_TOKEN", "")))
 APP_NAME = os.environ.get("SLACK_INTEGRATION_APP_NAME", os.environ.get("APP_NAME", "CAIPE"))
 _WORKSPACE_URL = os.environ.get("SLACK_WORKSPACE_URL", "").rstrip("/")
+_ROUTABLE_AMBIENT_MESSAGE_SUBTYPES = frozenset(
+  {None, "", "bot_message", "file_share"}
+)
 
 
 def _msg_link(channel_id: str, ts: str) -> str:
@@ -1740,7 +1743,13 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
     channel_id = event.get("channel")
     thread_ts = event.get("ts")
 
-    if event.get("subtype") and event.get("subtype") != "bot_message":
+    subtype = event.get("subtype")
+    if subtype not in _ROUTABLE_AMBIENT_MESSAGE_SUBTYPES:
+      logger.debug(
+        "[{}] Ignoring ambient Slack message subtype={}",
+        thread_ts,
+        subtype,
+      )
       return
 
     if not utils.verify_thread_exists(client, channel_id, thread_ts):
@@ -1754,13 +1763,27 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       user_id = event.get("user")
     team_id = event.get("team")
     message_text = slack_context.extract_message_text(event)
+    raw_files = event.get("files") or []
+
+    if raw_files:
+      logger.info(
+        "[{}] Processing Slack message attachments files={} has_text={} subtype={}",
+        thread_ts,
+        len(raw_files),
+        bool(message_text.strip()),
+        subtype or "none",
+      )
 
     user_name, user_email = utils.get_message_author_info(event, client)
     sender_label = "bot" if is_bot else "user"
 
     logger.info(f"[{thread_ts}] Routing {sender_label} message to agent={agent_match.agent_id} - User: {user_name} ({user_id}), Channel: {channel_id}{_msg_link(channel_id, thread_ts)}")
 
-    if not message_text or not message_text.strip():
+    if not message_text.strip() and not raw_files:
+      logger.debug(
+        "[{}] Ignoring ambient Slack message with no text or files",
+        thread_ts,
+      )
       return
 
     agent_id = agent_match.agent_id
@@ -1771,6 +1794,20 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
         "Slack channel grant denied for ambient message channel={} agent={} — silently dropping",
         channel_id,
         agent_id,
+      )
+      return
+
+    # Download attachments only after the route is authorized. If Slack file
+    # access is unavailable (for example, no files:read scope), the ingest
+    # notice is appended to the original text and CAIPE still handles the turn.
+    ingest = download_slack_files(raw_files, bot_token=client.token)
+    input_files = ingest.files
+    message_text = _apply_attachment_notices(message_text, ingest)
+
+    if not message_text.strip() and not input_files:
+      logger.info(
+        "[{}] Ignoring Slack file message with no usable text or attachments",
+        thread_ts,
       )
       return
 
@@ -1847,14 +1884,6 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
     )
 
     esc_config = get_escalation_config(agent_match)
-
-    # Download any Slack attachments into base64 multimodal blocks so the model
-    # can read them (client.token authenticates the private file URLs). Files
-    # that couldn't be accessed (e.g. missing files:read scope) surface as
-    # notices folded into the message so the agent can tell the user.
-    ingest = download_slack_files(event.get("files"), bot_token=client.token)
-    input_files = ingest.files
-    message_text = _apply_attachment_notices(message_text, ingest)
 
     result = _call_ai(
       client=client,

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_slack_file_share_routing.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_slack_file_share_routing.py
@@ -1,0 +1,265 @@
+"""Regression tests for Slack attachment messages on ambient channel routes."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import pathlib
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+_APP_PY = pathlib.Path(__file__).resolve().parents[1] / "app.py"
+_APP_DIR = _APP_PY.parent
+if str(_APP_DIR) not in sys.path:
+    sys.path.insert(0, str(_APP_DIR))
+
+_PNG = b"\x89PNG\r\n\x1a\nreal-image-bytes"
+
+
+class _HealthResponse:
+    ok = True
+    status_code = 200
+    text = "ok"
+
+
+class _SlackFileResponse:
+    def __init__(self, content: bytes, content_type: str) -> None:
+        self.content = content
+        self.headers = {"Content-Type": content_type}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _Client:
+    token = "xoxb-test-token"
+
+    def users_info(self, **_kwargs: object) -> dict[str, object]:
+        return {
+            "user": {
+                "real_name": "Test User",
+                "profile": {"email": "test-user@example.com"},
+            }
+        }
+
+
+def _load_slack_app(monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.syspath_prepend(str(_APP_DIR))
+    monkeypatch.setenv("SLACK_INTEGRATION_BOT_TOKEN", "xoxb-test-token")
+    monkeypatch.setenv("CAIPE_API_URL", "http://localhost:3000")
+    monkeypatch.setenv("CAIPE_CONNECT_RETRIES", "1")
+    monkeypatch.setenv("SLACK_RBAC_ENABLED", "false")
+    monkeypatch.setenv("SLACK_INTEGRATION_ENABLE_AUTH", "false")
+    monkeypatch.setattr(
+        "slack_sdk.web.client.WebClient.auth_test",
+        lambda _self, **_kwargs: {"ok": True, "user_id": "U-BOT"},
+    )
+    monkeypatch.setattr("requests.get", lambda *_args, **_kwargs: _HealthResponse())
+
+    for module_name in ("app", "utils.config", "utils.config_models"):
+        sys.modules.pop(module_name, None)
+
+    app_module = importlib.import_module("app")
+    monkeypatch.setattr(app_module, "_bind_obo_for_handler", lambda _context: None)
+    monkeypatch.setattr(
+        app_module.utils,
+        "verify_thread_exists",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        app_module.utils,
+        "get_channel_context",
+        lambda *_args, **_kwargs: {"topic": "", "purpose": ""},
+    )
+    monkeypatch.setattr(app_module, "_track_interaction", MagicMock())
+    monkeypatch.setattr(app_module, "_record_message_turns", MagicMock())
+    monkeypatch.setattr(app_module.session_manager, "set_thread_owner", MagicMock())
+    return app_module
+
+
+def _route_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    text: str,
+    subtype: str | None,
+    file_content: bytes,
+    content_type: str,
+) -> tuple[Any, MagicMock, MagicMock, MagicMock, MagicMock]:
+    app_module = _load_slack_app(monkeypatch)
+    config_models = importlib.import_module("utils.config_models")
+    file_ingest = importlib.import_module("utils.file_ingest")
+    agent_match = config_models.AgentBinding(
+        agent_id="example-agent",
+        users=config_models.UsersConfig(
+            enabled=True,
+            listen="message",
+            overthink=config_models.OverthinkConfig(enabled=True),
+        ),
+    )
+    channel_config = config_models.ChannelConfig(
+        name="#example",
+        agents=[agent_match],
+    )
+    event: dict[str, object] = {
+        "type": "message",
+        "channel": "C-EXAMPLE",
+        "user": "U-EXAMPLE",
+        "team": "T-EXAMPLE",
+        "ts": "1700000000.000100",
+        "text": text,
+        "files": [
+            {
+                "name": "image.png",
+                "mimetype": "image/png",
+                "url_private": "https://files.example.com/image.png",
+            }
+        ],
+    }
+    if subtype is not None:
+        event["subtype"] = subtype
+
+    download = MagicMock(
+        return_value=_SlackFileResponse(file_content, content_type),
+    )
+    call_ai = MagicMock(return_value=[])
+    create_conversation = MagicMock(
+        return_value={
+            "conversation_id": "conversation-example",
+            "created": True,
+            "metadata": {},
+        }
+    )
+    log = MagicMock()
+    monkeypatch.setattr(file_ingest.requests, "get", download)
+    monkeypatch.setattr(app_module, "_call_ai", call_ai)
+    monkeypatch.setattr(app_module, "logger", log)
+    monkeypatch.setattr(
+        app_module.sse_client,
+        "create_conversation",
+        create_conversation,
+    )
+
+    app_module._route_to_agent(
+        event,
+        say=MagicMock(),
+        client=_Client(),
+        channel_config=channel_config,
+        agent_match=agent_match,
+        is_bot=False,
+        context={},
+    )
+    return app_module, download, call_ai, create_conversation, log
+
+
+@pytest.mark.parametrize("subtype", [None, "file_share"])
+def test_caption_continues_when_attachment_is_inaccessible(
+    monkeypatch: pytest.MonkeyPatch,
+    subtype: str | None,
+) -> None:
+    """A real missing-scope response must preserve text and invoke CAIPE."""
+    _, download, call_ai, create_conversation, log = _route_fixture(
+        monkeypatch,
+        text="Please investigate this alert",
+        subtype=subtype,
+        file_content=b"<!DOCTYPE html><html>sign in</html>",
+        content_type="text/html; charset=utf-8",
+    )
+
+    download.assert_called_once()
+    create_conversation.assert_called_once()
+    call_ai.assert_called_once()
+    assert "Please investigate this alert" in call_ai.call_args.kwargs["message_text"]
+    assert "files:read" in call_ai.call_args.kwargs["message_text"]
+    assert call_ai.call_args.kwargs["files"] == []
+    assert call_ai.call_args.kwargs["overthink_config"].enabled is True
+    attachment_logs = [
+        call
+        for call in log.info.call_args_list
+        if "Processing Slack message attachments" in str(call.args[0])
+    ]
+    assert len(attachment_logs) == 1
+    assert attachment_logs[0].args[1:] == (
+        "1700000000.000100",
+        1,
+        True,
+        subtype or "none",
+    )
+
+
+def test_file_only_message_routes_usable_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real downloaded file must reach CAIPE when Slack supplies no text."""
+    _, download, call_ai, create_conversation, _ = _route_fixture(
+        monkeypatch,
+        text="",
+        subtype="file_share",
+        file_content=_PNG,
+        content_type="image/png",
+    )
+
+    download.assert_called_once()
+    create_conversation.assert_called_once()
+    call_ai.assert_called_once()
+    assert call_ai.call_args.kwargs["message_text"] == ""
+    assert call_ai.call_args.kwargs["files"] == [
+        {
+            "name": "image.png",
+            "mime_type": "image/png",
+            "data": base64.b64encode(_PNG).decode("ascii"),
+        }
+    ]
+
+
+def test_system_subtype_remains_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allowing file shares must not route Slack system messages."""
+    app_module = _load_slack_app(monkeypatch)
+    config_models = importlib.import_module("utils.config_models")
+    agent_match = config_models.AgentBinding(
+        agent_id="example-agent",
+        users=config_models.UsersConfig(enabled=True, listen="message"),
+    )
+    channel_config = config_models.ChannelConfig(
+        name="#example",
+        agents=[agent_match],
+    )
+    download = MagicMock()
+    create_conversation = MagicMock()
+    log = MagicMock()
+    file_ingest = importlib.import_module("utils.file_ingest")
+    monkeypatch.setattr(file_ingest.requests, "get", download)
+    monkeypatch.setattr(
+        app_module.sse_client,
+        "create_conversation",
+        create_conversation,
+    )
+    monkeypatch.setattr(app_module, "logger", log)
+
+    app_module._route_to_agent(
+        {
+            "type": "message",
+            "subtype": "channel_topic",
+            "channel": "C-EXAMPLE",
+            "user": "U-EXAMPLE",
+            "ts": "1700000000.000200",
+            "text": "topic changed",
+        },
+        say=MagicMock(),
+        client=_Client(),
+        channel_config=channel_config,
+        agent_match=agent_match,
+        is_bot=False,
+        context={},
+    )
+
+    download.assert_not_called()
+    create_conversation.assert_not_called()
+    assert any(
+        "Ignoring ambient Slack message subtype" in str(call.args[0])
+        for call in log.debug.call_args_list
+    )

--- a/docs/docs/integrations/slack-bot.md
+++ b/docs/docs/integrations/slack-bot.md
@@ -37,6 +37,12 @@ creates or resumes conversations, and streams responses through Dynamic Agents.
 | `chat:write` | Post replies |
 | `reactions:write` | Add feedback/status reactions |
 
+## Optional Slack Scopes
+
+| Scope | Purpose |
+|---|---|
+| `files:read` | Read files attached to messages. Without it, the bot continues with the message text and tells the user that it could not access the attachment. |
+
 ## Important Environment Variables
 
 | Variable | Purpose |

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.64 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.65 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.64 -f your-values.yaml'}
+                  {'    --version 0.5.65 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.64 -f your-values.yaml'}
+              {'    --version 0.5.65 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.65"
+version = "0.5.65-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.65"
+version = "0.5.65.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fix ambient Slack channel messages with file attachments being silently
discarded before CAIPE is invoked.

Slack can deliver these posts as `message` events with
`subtype="file_share"`. The ambient route previously accepted only messages
without a subtype or `bot_message`, so channels configured with
`listen: message` or `listen: all` matched an agent and then returned before
text extraction, attachment fallback, or Langfuse tracing.

This change:

- accepts both current attachment shapes: `files[]` with no subtype and
  `subtype="file_share"`;
- retains the guard for Slack system-message subtypes;
- treats attached files as input even when message text is empty;
- downloads files only after channel authorization;
- preserves and sends message text when an attachment is inaccessible, using
  the existing missing-`files:read` notice;
- adds one concise attachment-routing log and a debug log for intentionally
  ignored subtypes;
- documents `files:read` as optional because text-only fallback remains
  supported.

The regression tests pass realistic Slack events through `_route_to_agent` and
the real attachment-ingest function. They simulate Slack's HTTP 200 HTML
response for a missing scope, assert that CAIPE receives the original text plus
the notice with overthink enabled, verify a real PNG reaches CAIPE for a
file-only turn, and ensure system subtypes trigger neither download nor
conversation creation.

Follow-up to #2216.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; no chart changes.

## Validation

- `uv run --group unittest pytest tests -q -m 'not integration' --ignore=tests/test_langfuse_feedback.py` — 556 passed
- `uv run ruff check ai_platform_engineering/integrations/slack_bot/app.py ai_platform_engineering/integrations/slack_bot/tests/test_slack_file_share_routing.py`
- `git diff --check`

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
