### PR TITLE
docs(dynamic-agents): specify multi-harness support

### DIFF
--- a/docs/docs/specs/2026-08-02-dynamic-agent-multi-harness/research.md
+++ b/docs/docs/specs/2026-08-02-dynamic-agent-multi-harness/research.md
@@ -1,0 +1,522 @@
+---
+sidebar_position: 3
+sidebar_label: Research
+title: "Dynamic Agent Multi-Harness Research"
+---
+
+# Phase 0 Research: Dynamic Agent Multi-Harness Support
+
+## Executive conclusion
+
+CAIPE should support DeepAgents, Claude Agent SDK, and AgentCore Harness through a
+common harness contract, but it should not model all three as interchangeable
+"runtime backends."
+
+Two independent choices are required:
+
+1. **Harness** — owns the agent loop, tools, short-term context, and native events.
+2. **Execution provider** — owns hosting, deployment, lifecycle, isolation, and remote
+   invocation.
+
+The recommended delivery sequence is:
+
+1. Introduce the common contract and wrap the existing DeepAgents behavior.
+2. Implement a Claude Agent SDK adapter against Anthropic's public SDK contract.
+3. Add AgentCore Harness plus the AgentCore Runtime control plane.
+
+Claude Agent SDK is the best second implementation because it exercises a second local
+agent-loop contract without first introducing AWS provisioning, IAM, ECR, endpoints,
+version rollout, and asynchronous managed-resource state.
+
+## R-1 — Separate harness from execution provider
+
+**Decision**: Model harness selection and execution placement as separate fields.
+
+Illustrative configuration:
+
+```yaml
+harness:
+  type: deepagents | claude_agent_sdk | agentcore_harness
+  config: {}
+
+execution:
+  provider: local | agentcore_runtime
+  config: {}
+```
+
+**Rationale**:
+
+- DeepAgents and Claude Agent SDK are agent-loop implementations that CAIPE can host.
+- AgentCore Runtime is a serverless hosting environment for agent code.
+- AgentCore Harness is a managed Strands-powered loop that runs inside AgentCore
+  Runtime.
+- AgentCore Runtime can host custom frameworks, including LangGraph-based agents.
+- Keeping the axes separate avoids blocking future supported combinations.
+
+**Evidence**:
+
+- AWS distinguishes [AgentCore Harness from AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-vs-runtime.html): Runtime provides infrastructure while Harness provides the managed orchestration loop.
+- AWS documents AgentCore Runtime as a containerized hosting layer with sessions,
+  versions, endpoints, isolation, identity, streaming, and protocol support in
+  [How AgentCore Runtime works](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html).
+
+**Alternatives rejected**:
+
+- One `runtime_backend` enum containing `deepagents`, `claude`, and `agentcore` —
+  conflates execution logic with hosting and cannot accurately express AgentCore
+  Harness versus Runtime.
+- Deployment-wide harness selection — prevents mixed-harness agents in one CAIPE
+  installation and contradicts issue #2079.
+
+### Initial compatibility matrix
+
+| Harness | Local execution | AgentCore Runtime | Initial scope |
+|---|---:|---:|---|
+| DeepAgents | Required | Plausible follow-up | Existing default remains local |
+| Claude Agent SDK | Required | Evaluate later | First additional harness |
+| AgentCore Harness | Not applicable | Required | Managed AgentCore option |
+
+Unsupported pairs should be rejected by capability validation, not represented as
+partially working agents.
+
+## R-2 — Current Dynamic Agents code is coupled to DeepAgents/LangGraph
+
+**Decision**: Introduce the harness boundary before implementing either new harness.
+The first adapter wraps existing behavior without changing its user-visible contract.
+
+**Codebase findings**:
+
+- `AgentRuntime` imports `create_deep_agent` and DeepAgents backends directly:
+  `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py:23-27`.
+- `AgentRuntime` stores the concrete graph in `_graph`:
+  `agent_runtime.py:238-284`.
+- Initialization constructs the DeepAgents graph directly:
+  `agent_runtime.py:750-802`.
+- Streaming calls `_graph.astream(..., stream_mode=["messages", "updates", "tasks"])`:
+  `agent_runtime.py:1366-1379` and `1699-1712`.
+- The stream encoder abstraction still accepts raw LangGraph tuples in `on_chunk`:
+  `services/stream_encoders/__init__.py:20-51`.
+- Conversation routes reach through the runtime boundary to inspect `_graph`:
+  `routes/conversations.py:100-127`.
+- `AgentRuntimeCache` constructs the concrete `AgentRuntime` directly:
+  `services/runtime_cache.py:240`, `278`, and `327`.
+- `AgentBackend` already means filesystem/checkpoint storage strategy, not agentic
+  harness: `models.py:180-228`. The new abstraction must not overload this name.
+
+**Implication**: Adding SDK-specific branches inside `AgentRuntime.stream()` would
+spread conditionals into caching, conversations, interrupts, streaming, metrics, and
+tests. The shared runtime needs to depend on a harness-neutral interface first.
+
+## R-3 — Build the Claude adapter from the public SDK contract
+
+**Decision**: Implement Claude Agent SDK support directly against Anthropic's documented
+Python API and isolate all SDK-specific types inside the adapter.
+
+### Public API surface to map
+
+| SDK surface | Adapter responsibility |
+|---|---|
+| `ClaudeSDKClient` | Continuous conversation lifecycle, query submission, response streaming, interruption, and shutdown |
+| `ClaudeAgentOptions` | Model, instructions, working directory, allowed tools, MCP servers, permissions, hooks, skills, limits, environment, and session options |
+| Assistant and content-block messages | Text, thinking, tool start, and tool result translation |
+| System and result messages | Session initialization, terminal result, usage, cost when available, and error classification |
+| Task messages | Subagent start, progress, usage, and terminal translation |
+| Session APIs | Capture, resume, fork, and shared-store behavior |
+
+Anthropic documents the Agent SDK as a Python or TypeScript library that provides the
+same agent loop, tools, context management, hooks, MCP, subagents, permissions, and
+sessions as Claude Code in the
+[Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview).
+
+The public [Python SDK reference](https://code.claude.com/docs/en/agent-sdk/python)
+defines the client, options, message types, task messages, content blocks, hooks,
+permissions, MCP configuration, and error taxonomy needed by the adapter.
+
+### Required security controls
+
+- Task-local connector credentials rather than ambient user-token fallback
+- Allowed-tool restriction
+- Read and write confinement to the run workspace
+- Denial or approval of unsafe and interactive tools
+- Pre-tool authorization and audit hooks
+- Post-tool audit and bounded persistence integration
+
+**Alternatives rejected**:
+
+- Expose SDK-native messages to CAIPE clients — couples public protocols to one SDK.
+- Spread Claude-specific branches through the existing runtime — recreates the current
+  DeepAgents coupling.
+- Depend on undocumented message shapes — makes SDK upgrades unsafe and difficult to
+  validate.
+
+## R-4 — Normalize harness events before protocol encoding
+
+**Decision**: Every adapter emits a common `HarnessEvent`. Protocol encoders consume
+common events rather than native LangGraph chunks, Claude SDK messages, or AgentCore
+events.
+
+```mermaid
+flowchart LR
+    D["DeepAgents adapter"] --> E["Common HarnessEvent stream"]
+    C["Claude SDK adapter"] --> E
+    A["AgentCore adapter"] --> E
+    E --> S["Custom SSE encoder"]
+    E --> G["AG-UI encoder"]
+    E --> P["A2A / future encoders"]
+    E --> O["Audit and AgentOps"]
+```
+
+### Minimum common event taxonomy
+
+| Event | Required semantics |
+|---|---|
+| `run_started` | CAIPE run and conversation correlation established |
+| `text_delta` | Ordered visible or narrated text fragment |
+| `tool_started` | Correlated tool name and redacted input |
+| `tool_finished` | Correlated success/error and bounded result |
+| `subagent_started` | Child task identity and parent correlation |
+| `subagent_progress` | Non-terminal child activity |
+| `subagent_finished` | Child terminal result |
+| `input_required` | Approval, form input, or other supported human decision |
+| `usage_updated` | Tokens, context utilization, cost, or provider usage when available |
+| `session_updated` | Native session or binding changed |
+| `warning` | Non-terminal degraded behavior |
+| `run_completed` | Successful terminal outcome |
+| `run_cancelled` | Cancelled terminal outcome |
+| `run_failed` | Failed terminal outcome with stable error category |
+
+Each event should carry:
+
+- CAIPE run, conversation, and agent identifiers
+- Harness and execution-provider identifiers
+- Sequence or ordering data
+- Tool/subagent correlation identifiers where relevant
+- Timestamp
+- Safe structured payload
+- Optional bounded and redacted native metadata for diagnosis
+
+**Invariant**: one run produces exactly one terminal event. Translators must tolerate
+unknown native message types, but unknown terminal behavior is an error rather than a
+silent success.
+
+**Alternatives rejected**:
+
+- Teach every protocol encoder every SDK's native event types — multiplies coupling by
+  harnesses × protocols.
+- Use the existing raw LangGraph tuple as the common model — cannot accurately represent
+  Claude task messages or AgentCore lifecycle events and preserves the current coupling.
+
+## R-5 — Use a composed adapter and execution-provider contract
+
+**Decision**: Use composition and dependency injection rather than subclasses of the
+current concrete `AgentRuntime`.
+
+Illustrative responsibilities:
+
+```python
+class HarnessAdapter(Protocol):
+    def capabilities(self) -> HarnessCapabilities: ...
+    def validate(self, spec: AgentSpec) -> None: ...
+    async def initialize(self, context: ExecutionContext) -> None: ...
+    async def stream(self, turn: AgentTurn) -> AsyncIterator[HarnessEvent]: ...
+    async def resume(self, input: ResumeInput) -> AsyncIterator[HarnessEvent]: ...
+    async def cancel(self) -> None: ...
+    async def close(self) -> None: ...
+
+
+class ExecutionProvider(Protocol):
+    async def reconcile(self, desired: DeploymentSpec) -> ProviderBinding: ...
+    async def status(self, binding: ProviderBinding) -> ProviderStatus: ...
+    async def invoke(self, binding: ProviderBinding, request: InvokeRequest): ...
+    async def delete(self, binding: ProviderBinding) -> None: ...
+```
+
+The exact method signatures belong in the implementation plan and contracts. The
+research decision is the separation of responsibilities:
+
+- Harness adapter: model/tool/skill translation, native session behavior, native event
+  conversion, in-run cancellation and approvals.
+- Execution provider: provision, version, endpoint, invoke transport, health, lifecycle,
+  and delete.
+- Shared Dynamic Agents service: authorization, configuration, conversation identity,
+  common events, protocol encoding, audit, and client-facing errors.
+
+## R-6 — Capabilities are explicit; parity does not mean pretending
+
+**Decision**: Each harness declares supported capabilities and constraints. Save-time
+validation rejects incompatible configurations.
+
+### Research capability matrix
+
+| Capability | DeepAgents | Claude Agent SDK | AgentCore Harness |
+|---|---|---|---|
+| Agent loop owner | CAIPE library | Claude Agent SDK | AWS managed harness |
+| Initial execution | Local CAIPE service | Local CAIPE service/process | AgentCore Runtime |
+| Streaming | LangGraph stream modes | SDK message stream | Managed response stream |
+| MCP tools | Existing CAIPE MCP client | SDK MCP server configuration | Remote MCP supported |
+| Built-in file/shell tools | DeepAgents backend/tools | SDK built-ins | Managed shell/file tools |
+| Hooks | DeepAgents middleware | Pre/post lifecycle hooks | Not supported by Harness |
+| Subagents | DeepAgents task delegation | SDK task/subagent messages | Harness-managed features; validate exact configuration |
+| Human approval | Existing interrupt model | SDK permissions/input flow; adapter mapping required | Capability-specific; no hook emulation |
+| Short-term context | LangGraph checkpointer | SDK session transcript | AgentCore session/memory configuration |
+| Durable cross-host resume | Mongo checkpointer | External/shared session persistence required | AgentCore Memory or CAIPE-owned context required |
+| Deployment lifecycle | Process/container lifecycle | Process/container lifecycle | AWS create/update/version/endpoint/delete |
+
+Anthropic's [Python SDK reference](https://code.claude.com/docs/en/agent-sdk/python)
+recommends `ClaudeSDKClient` for continuous conversations, session control, streaming,
+interrupts, hooks, and custom tools. Anthropic's
+[session documentation](https://code.claude.com/docs/en/agent-sdk/sessions) states that
+Python sessions are written to local disk and that cross-host or ephemeral execution
+requires moving the transcript or using shared external session storage.
+
+AWS's current [Harness versus Runtime feature grid](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-vs-runtime.html)
+shows an important incompatibility: AgentCore Harness does not expose hooks, arbitrary
+framework choice, bidirectional streaming, or non-agent-loop graph patterns, while
+custom code on AgentCore Runtime can implement those behaviors.
+
+**Implication**: The UI cannot display a single undifferentiated set of controls. It
+must derive supported models, tools, approvals, memory, skills, and execution options
+from the selected harness and provider.
+
+## R-7 — CAIPE owns identity, conversation, and audit; harnesses own native context
+
+**Decision**: CAIPE remains the canonical control-plane and audit system. Store native
+session identifiers as bindings rather than treating native transcripts as the only
+conversation record.
+
+### Ownership model
+
+| Concern | Owner |
+|---|---|
+| Agent definition and access policy | CAIPE |
+| User-facing conversation ID | CAIPE |
+| Authorization decision | CAIPE/OpenFGA and downstream policy enforcement |
+| Normalized event/audit history | CAIPE |
+| Native short-term agent context | Selected harness |
+| Native session/resource ID | Harness binding stored by CAIPE |
+| Durable long-term memory | Explicit configured provider; never implied by a runtime session |
+
+**Rationale**:
+
+- DeepAgents checkpoints, Claude transcripts, and AgentCore sessions have different
+  storage and lifetime semantics.
+- Continuous bidirectional synchronization would be expensive, lossy, and prone to
+  duplicated context.
+- A binding lets CAIPE resume the native context when available while retaining stable
+  user-facing identity and audit records.
+
+### Claude session implication
+
+Dynamic Agents must capture native session IDs and define explicit behavior for resume
+failure, compaction, and unavailable transcripts. Production cross-replica resume must
+use the supported shared session-store mechanism or deliberately reconstruct a fresh
+prompt from CAIPE-owned state.
+
+### AgentCore session implication
+
+AWS documents runtime sessions as isolated execution environments that can be
+terminated after idle or maximum lifetime. Runtime filesystem/context is ephemeral;
+durable history must use AgentCore Memory or CAIPE-owned state. A CAIPE conversation
+therefore cannot assume its `runtimeSessionId` always points to a live microVM.
+
+## R-8 — Authorization remains outside the harness
+
+**Decision**: All harnesses receive a validated `ExecutionContext`; none may replace
+CAIPE/OpenFGA authorization with framework-local tool permissions.
+
+Required controls:
+
+- Authenticate and authorize agent use before adapter initialization or remote invoke.
+- Preserve the caller's delegated identity on MCP calls.
+- Fail closed when caller identity or required delegated credentials are missing.
+- Constrain built-in file and shell tools to an isolated workspace.
+- Treat Claude hooks and DeepAgents middleware as defense-in-depth controls.
+- Use IAM or OAuth for AgentCore inbound access and least-privilege outbound identity.
+- Redact secrets and sensitive tool inputs/results before normalized events, logs, and
+  traces are persisted.
+- Prevent provider environment variables from becoming an ambient fallback user
+  identity.
+
+Task-local connector credentials and filesystem confinement are required regardless of
+the selected SDK. Anthropic documents deterministic pre-tool hooks for validation and
+audit in [Agent SDK hooks](https://code.claude.com/docs/en/agent-sdk/hooks). AgentCore
+Harness does not offer equivalent hooks, which reinforces the need for authorization
+at CAIPE and MCP enforcement boundaries.
+
+## R-9 — AgentCore requires an asynchronous control plane
+
+**Decision**: Treat AgentCore configuration changes as desired-state reconciliation,
+not synchronous CRUD that assumes the remote resource is immediately ready.
+
+Required managed states include:
+
+- `pending_create`
+- `creating`
+- `ready`
+- `updating`
+- `update_failed`
+- `deleting`
+- `delete_failed`
+- `deleted`
+- `drifted`
+
+The binding needs, at minimum:
+
+- CAIPE agent ID
+- AWS account/region reference
+- Harness/runtime resource identifier or ARN
+- Endpoint and immutable version
+- Desired configuration revision
+- Observed lifecycle state and reason
+- Last reconciliation time
+- Native session mapping per conversation
+
+Reconciliation must be idempotent. A network timeout after AWS accepts a create or
+update request cannot cause uncontrolled duplicate resources on retry.
+
+AWS documents immutable runtime versions, addressable endpoints, and asynchronous
+endpoint lifecycle states in
+[AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html).
+
+## R-10 — Claude SDK versioning needs an explicit compatibility gate
+
+**Decision**: Pin a reviewed Claude Agent SDK version and test its native message
+contract. Do not depend on undocumented message shapes.
+
+**Rationale**:
+
+- The SDK exposes a broad and evolving message taxonomy.
+- The current official Python API includes session stores, interrupts, hooks, custom
+  transports, task messages, and multiple tool types.
+- An unknown native message should be observable and safely ignored only when it is
+  non-terminal; unknown terminal semantics must fail visibly.
+
+Minimum compatibility coverage:
+
+- SDK client startup and shutdown
+- Partial text messages
+- Tool start/result correlation
+- System initialization and session ID
+- Successful and failed result messages
+- Context/token/cost usage when available
+- Task/subagent start, progress, and terminal notifications
+- Interrupt and cancellation behavior
+- Resume, missing transcript, and shared-store behavior
+- Hook allow, deny, mutation, timeout, and failure behavior
+- MCP connection and credential propagation
+
+## R-11 — Roll out Claude before AgentCore
+
+**Decision**: Use the following delivery order.
+
+### Phase A — Common foundation and DeepAgents wrapper
+
+- Define harness capabilities and configuration validation.
+- Define the common event contract.
+- Move LangGraph parsing into the DeepAgents adapter.
+- Make cache, chat, resume, conversation-state, and encoders depend on the common
+  contract.
+- Preserve current behavior and protocol output.
+
+### Phase B — Claude Agent SDK adapter
+
+- Implement SDK message translation and option construction from the public API.
+- Implement CAIPE workspace, credential, MCP, session, approval, cancellation, and
+  telemetry integration.
+- Add native SDK compatibility and common conformance tests.
+- Enable per-agent selection for DeepAgents and Claude.
+
+### Phase C — AgentCore Harness and Runtime provider
+
+- Add AWS credentials, network, identity, and region configuration.
+- Implement desired-state reconciliation and managed bindings.
+- Map AgentCore invocation, sessions, streaming, memory, traces, and errors.
+- Add lifecycle UI and AgentOps correlation.
+- Enable AgentCore only after provisioning and deletion tests are idempotent.
+
+### Phase D — Follow-up harnesses and execution combinations
+
+- Evaluate Google ADK and standalone Strands adapters under issue #2079.
+- Evaluate DeepAgents or Claude SDK hosted on AgentCore Runtime only when a concrete
+  deployment need exists.
+- Evaluate cross-harness delegation through an explicit A2A or routing contract.
+
+**Why Claude first**: It is the second concrete implementation needed to prove the
+abstraction, aligns with the Constitution's Rule of Three, and isolates adapter design
+from remote control-plane complexity.
+
+## R-12 — Estimated effort and staffing
+
+| Workstream | Estimated effort |
+|---|---:|
+| Common contract, event model, and DeepAgents wrapper | 2–3 engineer-weeks |
+| Claude Agent SDK adapter | 3–5 engineer-weeks |
+| AgentCore Harness and Runtime control/data plane | 8–12 engineer-weeks |
+| Cross-harness UI, conformance, security, and operational hardening | 2–3 engineer-weeks |
+| **Total** | **15–23 engineer-weeks** |
+
+Expected elapsed time is approximately **8–12 calendar weeks with two engineers**, with
+the Claude-enabled local multi-harness milestone available before AgentCore completion.
+
+The largest uncertainty is AgentCore enterprise integration rather than SDK invocation:
+
+- AWS account and IAM ownership
+- VPC/DNS/egress access to CAIPE MCP servers
+- Caller identity and credential exchange
+- Resource reconciliation and rollback
+- Memory ownership and retention
+- AgentOps trace/log correlation
+- Cost attribution and quotas
+
+## R-13 — Issue structure
+
+**Decision**:
+
+- Keep [#2079](https://github.com/cnoe-io/ai-platform-engineering/issues/2079) as the multi-harness umbrella.
+- Add a child issue for the common harness contract and DeepAgents wrapper.
+- Add a child issue for the Claude Agent SDK adapter.
+- Split [#2109](https://github.com/cnoe-io/ai-platform-engineering/issues/2109) into:
+  - AgentCore Harness adapter
+  - AgentCore Runtime execution provider and reconciliation
+  - AgentCore identity, MCP networking, memory, and AgentOps integration
+
+This preserves the distinction already present in the issue intent: #2079 concerns
+agentic SDK choice, while #2109 concerns an optional AWS-managed backend.
+
+## Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Common contract becomes a lowest-common-denominator API | Harness-native value is lost | Mandatory core events plus declared optional capabilities and bounded native metadata |
+| Shared runtime remains coupled to LangGraph | New adapters require invasive branches | Make DeepAgents consume the same contract before adding Claude |
+| Claude sessions disappear on replica replacement | Follow-up loses context | Shared `SessionStore` or explicit CAIPE-state recovery policy; test cross-host resume |
+| Claude built-in tools bypass CAIPE boundaries | Unauthorized file or command execution | Isolated workspace, tool allowlist, hooks, sandboxing, and authorization outside the SDK |
+| AgentCore provisioning and CAIPE state diverge | Leaked or unusable AWS resources | Idempotent desired-state reconciliation and drift detection |
+| AgentCore session expiry is mistaken for durable memory | Lost conversation context | Explicit memory policy and CAIPE-owned conversation record |
+| MCP servers are unreachable from AgentCore | Agent runs without required tools | Preflight networking/identity validation before marking the managed agent ready |
+| Provider-specific events break clients | UI/protocol regressions | Normalize before encoding; common conformance and golden-stream tests |
+| SDK upgrades introduce unknown message types | Missing output or false completion | Pinned versions, compatibility fixtures, unknown-event metrics, terminal-event invariants |
+| Capability differences are hidden | Misconfigured or silently degraded agents | Capability registry and save-time validation in UI and API |
+
+## Sources
+
+### CAIPE
+
+- [CAIPE issue #2079: Multiple Agentic Harness SDK Integration](https://github.com/cnoe-io/ai-platform-engineering/issues/2079)
+- [CAIPE issue #2109: Amazon Bedrock AgentCore Integration](https://github.com/cnoe-io/ai-platform-engineering/issues/2109)
+
+### Anthropic
+
+- [Claude Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview)
+- [Claude Agent SDK Python reference](https://code.claude.com/docs/en/agent-sdk/python)
+- [Claude Agent SDK sessions](https://code.claude.com/docs/en/agent-sdk/sessions)
+- [Claude Agent SDK hooks](https://code.claude.com/docs/en/agent-sdk/hooks)
+
+### AWS
+
+- [AgentCore Harness versus Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-vs-runtime.html)
+- [How AgentCore Runtime works](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)
+- [AgentCore Runtime lifecycle settings](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-lifecycle-settings.html)
+
+**Research date**: 2026-08-02. External product behavior must be revalidated during
+implementation because both Claude Agent SDK and AgentCore are actively evolving.

--- a/docs/docs/specs/2026-08-02-dynamic-agent-multi-harness/research.md
+++ b/docs/docs/specs/2026-08-02-dynamic-agent-multi-harness/research.md
@@ -343,7 +343,144 @@ audit in [Agent SDK hooks](https://code.claude.com/docs/en/agent-sdk/hooks). Age
 Harness does not offer equivalent hooks, which reinforces the need for authorization
 at CAIPE and MCP enforcement boundaries.
 
-## R-9 — AgentCore requires an asynchronous control plane
+## R-9 — AgentCore is a first-class requested product path
+
+**Decision**: Treat [#2109](https://github.com/cnoe-io/ai-platform-engineering/issues/2109)
+as a high-priority implementation track, not a speculative deployment follow-up.
+
+The initial AgentCore outcome must let an operator:
+
+- Select AgentCore Harness when defining a dynamic agent.
+- Provision, update, promote, invoke, observe, and delete the managed resource from
+  CAIPE.
+- Connect approved MCP tools without losing CAIPE caller identity or policy controls.
+- Choose explicit memory behavior and retention.
+- Correlate a CAIPE conversation and audit event with its AWS session and trace.
+- See readiness, deployment failure, drift, quota, and invocation errors in CAIPE.
+
+This priority comes from the explicit public feature request. The research does not
+infer a request count that the public issue tracker does not provide.
+
+## R-10 — Managed Harness is the AgentCore MVP; Runtime stays a separate provider
+
+**Decision**: The first AgentCore option uses the managed, configuration-driven
+AgentCore Harness. Hosting arbitrary framework code directly on AgentCore Runtime is a
+separate execution-provider capability.
+
+AWS describes Harness as a managed Strands-powered agent loop backed by Runtime. It
+manages the execution environment, session isolation, memory, identity, networking,
+and observability from declarative model, instruction, tool, and skill configuration.
+Runtime supplies hosting but does not supply an agent loop.
+
+### MVP boundary
+
+| Included in the AgentCore MVP | Deferred or separately selectable |
+|---|---|
+| Create, update, version, promote, invoke, and delete Harness resources | Host DeepAgents or Claude Agent SDK code on Runtime |
+| Managed response streaming mapped to common CAIPE events | Bidirectional streaming or hook emulation |
+| Remote MCP or AgentCore Gateway tools | Arbitrary non-agent-loop graphs |
+| AgentCore Memory modes and CAIPE conversation binding | Automatic migration of existing LangGraph checkpoints |
+| IAM/OAuth ingress, delegated tool identity, and AgentOps correlation | Browser and Code Interpreter enabled without an explicit policy |
+
+The capability registry must expose Harness limitations. In particular, CAIPE must not
+advertise hooks, arbitrary framework choice, bidirectional streaming, or graph-shaped
+execution when the selected resource is managed Harness.
+
+Sources: [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html),
+[Harness versus Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-vs-runtime.html),
+and [AgentCore tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html).
+
+## R-11 — Map CAIPE resources to immutable AgentCore versions and endpoints
+
+**Decision**: Store a durable AgentCore binding and promote immutable versions through
+named endpoints. Production traffic must not rely on the `DEFAULT` endpoint following
+the latest version automatically.
+
+| CAIPE concept | AgentCore representation |
+|---|---|
+| Dynamic agent | Harness resource ARN |
+| Saved configuration revision | Immutable Harness version |
+| Environment or release channel | Named endpoint pinned to a version |
+| Conversation | CAIPE conversation ID plus `runtimeSessionId` and optional actor ID |
+| Approved tool set | Remote MCP or Gateway tool configuration |
+| Managed memory selection | Memory resource/configuration stored in the binding |
+| AgentOps execution | AWS session, trace, span, endpoint, and version identifiers |
+| Credential reference | Identity provider/workload identity reference; never raw credentials |
+
+Every update creates or identifies an immutable version. Promotion moves a named
+endpoint only after validation. Rollback repoints the endpoint to the last known-good
+version without rewriting the CAIPE agent definition.
+
+AWS documents immutable Harness versions and `CREATING`, `CREATE_FAILED`, `READY`,
+`UPDATING`, and `UPDATE_FAILED` endpoint states in
+[Harness versioning and endpoints](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-versioning.html).
+
+## R-12 — Preserve CAIPE caller identity through AgentCore
+
+**Decision**: CAIPE remains the authorization boundary. AgentCore provides workload
+identity and token exchange for downstream calls; it does not replace CAIPE/OpenFGA or
+MCP-server authorization.
+
+The implementation spike must validate two supported connection patterns:
+
+1. AgentCore invokes an approved CAIPE MCP endpoint with a delegated caller token or a
+   signed CAIPE execution context.
+2. AgentCore Gateway fronts approved tools and AgentCore Identity performs on-behalf-of
+   token exchange for the downstream audience.
+
+Select one pattern per deployment. Do not duplicate existing CAIPE/OpenFGA rules in
+AgentCore Policy during the MVP; a second policy plane requires its own ownership,
+consistency, and audit design.
+
+Required security behavior:
+
+- Choose IAM SigV4 or OAuth/JWT ingress when creating the resource; do not assume both
+  are simultaneously active on one Runtime resource.
+- Authorize the CAIPE user before the service invokes AgentCore.
+- Carry stable workload, actor, conversation, and request identifiers downstream.
+- Restrict the AWS execution role and resource policy to the selected account, region,
+  resources, and actions.
+- Use on-behalf-of exchange only for an allowed issuer, audience, scope, and tool.
+- Fail closed when token exchange, identity mapping, or policy context is unavailable.
+
+AgentCore Identity supports OAuth token exchange, including RFC 8693 and RFC 7523
+patterns. The spike must prove compatibility with the deployment's identity provider
+and the actual CAIPE MCP boundary before implementation is considered unblocked.
+
+Sources: [Runtime OAuth](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html),
+[on-behalf-of token exchange](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/on-behalf-of-token-exchange.html),
+[IAM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-iam.html),
+and [resource-based policies](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/resource-based-policies.html).
+
+## R-13 — Make AgentCore memory mode explicit
+
+**Decision**: An AgentCore agent must select one of three memory modes. CAIPE remains
+the canonical conversation and audit record in every mode.
+
+| Mode | Behavior | Required binding data |
+|---|---|---|
+| Disabled | No AgentCore Memory persistence | Session mapping only |
+| Managed | CAIPE provisions/configures AgentCore Memory | Memory ARN, actor scope, session mapping, retention policy |
+| Bring your own | Operator supplies an allowed existing memory resource | Validated resource reference, actor scope, session mapping, retention owner |
+
+AgentCore Harness enables memory by default, but CAIPE must never silently accept that
+default. The operator needs to see the selected mode and its retention/deletion
+consequences.
+
+Implementation requirements:
+
+- Use a tenant- and user-safe actor ID mapping; never reuse a global actor ID.
+- Keep `runtimeSessionId` separate from durable memory identity.
+- Define what deletion removes from CAIPE, Harness, and Memory.
+- Define retention, export, legal hold, and region behavior before managed long-term
+  memory is generally available.
+- Do not place secrets or unrestricted tool results into long-term memory.
+
+AWS distinguishes short-term raw events from long-term semantic, summary, preference,
+episodic, and custom strategies in
+[AgentCore Harness memory](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-memory.html).
+
+## R-14 — AgentCore requires an asynchronous, idempotent control plane
 
 **Decision**: Treat AgentCore configuration changes as desired-state reconciliation,
 not synchronous CRUD that assumes the remote resource is immediately ready.
@@ -362,23 +499,53 @@ Required managed states include:
 
 The binding needs, at minimum:
 
-- CAIPE agent ID
-- AWS account/region reference
-- Harness/runtime resource identifier or ARN
-- Endpoint and immutable version
-- Desired configuration revision
-- Observed lifecycle state and reason
-- Last reconciliation time
+- CAIPE agent ID and desired configuration revision
+- AWS account and region reference
+- Harness/runtime ARN
+- Immutable version and named endpoint
+- Memory and identity references
+- Observed lifecycle state, reason, and last reconciliation time
 - Native session mapping per conversation
 
-Reconciliation must be idempotent. A network timeout after AWS accepts a create or
-update request cannot cause uncontrolled duplicate resources on retry.
+Reconciliation must be idempotent. A network timeout after AWS accepts a create,
+update, endpoint promotion, or delete request cannot create duplicate resources or
+lose the last known-good binding. Deletion must account for retained versions, named
+endpoints, memory resources, and externally owned dependencies.
 
-AWS documents immutable runtime versions, addressable endpoints, and asynchronous
-endpoint lifecycle states in
-[AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html).
+## R-15 — AgentCore needs explicit operational, cost, and quota gates
 
-## R-10 — Claude SDK versioning needs an explicit compatibility gate
+**Decision**: A managed AgentCore binding cannot become `ready` until deployment
+preflight validates region, IAM, networking, MCP reachability, identity exchange,
+service quotas, model access, and observability.
+
+### AgentOps mapping
+
+- Propagate CAIPE request, conversation, agent, tenant, endpoint, and version IDs.
+- Record AWS session, trace, and span IDs on normalized audit events.
+- Enable CloudWatch Transaction Search and OpenTelemetry/ADOT integration where
+  required for trace detail.
+- Export availability, latency, token/model usage, tool failures, throttling, session
+  saturation, and reconciliation errors without copying secrets or unrestricted tool
+  content.
+- Distinguish Harness, model, Memory, Gateway, and built-in-tool cost attribution.
+
+AWS states that Harness has no separate charge; the deployment pays for the underlying
+AgentCore capabilities and model use. CAIPE must still support budgets, usage tags,
+and per-agent cost correlation before broad enablement.
+
+### Limits to preflight
+
+AWS documents regional/account quotas and Runtime-backed Harness limits for active
+sessions, resource/version/endpoint counts, request rates, compute size, image size,
+and synchronous, streaming, and asynchronous execution duration. These values are
+deployment inputs, not constants in the CAIPE contract. Discover or configure them at
+deployment time and surface actionable failures before traffic is routed.
+
+Sources: [AgentCore quotas](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/bedrock-agentcore-limits.html),
+[observability](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-get-started.html),
+and [telemetry model](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-telemetry.html).
+
+## R-16 — Claude SDK versioning needs an explicit compatibility gate
 
 **Decision**: Pin a reviewed Claude Agent SDK version and test its native message
 contract. Do not depend on undocumented message shapes.
@@ -405,7 +572,7 @@ Minimum compatibility coverage:
 - Hook allow, deny, mutation, timeout, and failure behavior
 - MCP connection and credential propagation
 
-## R-11 — Roll out Claude before AgentCore
+## R-17 — Prove the local abstraction, then deliver AgentCore in gated increments
 
 **Decision**: Use the following delivery order.
 
@@ -426,13 +593,34 @@ Minimum compatibility coverage:
 - Add native SDK compatibility and common conformance tests.
 - Enable per-agent selection for DeepAgents and Claude.
 
-### Phase C — AgentCore Harness and Runtime provider
+### Phase C1 — AgentCore integration spike
 
-- Add AWS credentials, network, identity, and region configuration.
-- Implement desired-state reconciliation and managed bindings.
-- Map AgentCore invocation, sessions, streaming, memory, traces, and errors.
-- Add lifecycle UI and AgentOps correlation.
-- Enable AgentCore only after provisioning and deletion tests are idempotent.
+- Prove IAM/OAuth ingress and delegated caller identity with the deployment's identity
+  provider.
+- Prove remote MCP connectivity, DNS, TLS, egress, token exchange, and fail-closed
+  behavior.
+- Capture real Harness streaming events and map them to the common contract.
+- Validate Memory actor/session isolation and AgentOps trace correlation.
+- Confirm quotas, regions, model access, and expected cost attribution.
+
+### Phase C2 — AgentCore control plane
+
+- Implement desired-state reconciliation, bindings, immutable versions, named
+  endpoints, promotion, rollback, drift detection, and deletion.
+- Add lifecycle status and actionable failure details to the API and UI.
+
+### Phase C3 — AgentCore data plane
+
+- Implement Harness configuration and invocation adapters.
+- Map sessions, streaming, tools, memory, traces, errors, cancellation, and timeouts.
+- Add common conformance and golden-stream tests.
+
+### Phase C4 — AgentCore operational hardening
+
+- Add quota and model-access preflight, cost/usage attribution, dashboards, alerts,
+  audit correlation, and failure injection.
+- Enable AgentCore only after create, update, promotion, rollback, and deletion tests
+  are idempotent and identity/MCP tests fail closed.
 
 ### Phase D — Follow-up harnesses and execution combinations
 
@@ -445,7 +633,7 @@ Minimum compatibility coverage:
 abstraction, aligns with the Constitution's Rule of Three, and isolates adapter design
 from remote control-plane complexity.
 
-## R-12 — Estimated effort and staffing
+## R-18 — Estimated effort and staffing
 
 | Workstream | Estimated effort |
 |---|---:|
@@ -468,7 +656,17 @@ The largest uncertainty is AgentCore enterprise integration rather than SDK invo
 - AgentOps trace/log correlation
 - Cost attribution and quotas
 
-## R-13 — Issue structure
+### AgentCore estimate decomposition
+
+| AgentCore workstream | Estimated effort |
+|---|---:|
+| Security, networking, identity, and event-mapping spike | 1–2 engineer-weeks |
+| Harness adapter and streaming data plane | 2–3 engineer-weeks |
+| Reconciliation, versions, endpoints, promotion, and deletion | 2–3 engineer-weeks |
+| MCP identity, memory, AgentOps, quota, and failure hardening | 3–4 engineer-weeks |
+| **AgentCore total** | **8–12 engineer-weeks** |
+
+## R-19 — Issue structure
 
 **Decision**:
 
@@ -476,9 +674,10 @@ The largest uncertainty is AgentCore enterprise integration rather than SDK invo
 - Add a child issue for the common harness contract and DeepAgents wrapper.
 - Add a child issue for the Claude Agent SDK adapter.
 - Split [#2109](https://github.com/cnoe-io/ai-platform-engineering/issues/2109) into:
+  - AgentCore security, network, identity, Memory, and event-mapping spike
   - AgentCore Harness adapter
-  - AgentCore Runtime execution provider and reconciliation
-  - AgentCore identity, MCP networking, memory, and AgentOps integration
+  - AgentCore control plane, versions, endpoints, promotion, and deletion
+  - AgentCore MCP identity, AgentOps, quota, cost, and failure hardening
 
 This preserves the distinction already present in the issue intent: #2079 concerns
 agentic SDK choice, while #2109 concerns an optional AWS-managed backend.
@@ -493,7 +692,15 @@ agentic SDK choice, while #2109 concerns an optional AWS-managed backend.
 | Claude built-in tools bypass CAIPE boundaries | Unauthorized file or command execution | Isolated workspace, tool allowlist, hooks, sandboxing, and authorization outside the SDK |
 | AgentCore provisioning and CAIPE state diverge | Leaked or unusable AWS resources | Idempotent desired-state reconciliation and drift detection |
 | AgentCore session expiry is mistaken for durable memory | Lost conversation context | Explicit memory policy and CAIPE-owned conversation record |
+| AgentCore actor IDs are shared across users or tenants | Cross-user memory disclosure | Tenant-scoped actor mapping and isolation tests |
 | MCP servers are unreachable from AgentCore | Agent runs without required tools | Preflight networking/identity validation before marking the managed agent ready |
+| Ingress auth mode is chosen incorrectly | Invocation outage or weakened access boundary | Make IAM versus OAuth an immutable, validated deployment decision |
+| CAIPE and AgentCore Policy become competing policy planes | Inconsistent allow/deny outcomes | Keep CAIPE/OpenFGA and MCP enforcement canonical in MVP; design policy synchronization separately |
+| `DEFAULT` endpoint follows an unvalidated version | Production changes without promotion | Route production through named, pinned endpoints |
+| Per-invocation model overrides bypass policy or budgets | Compliance and cost exposure | Capability/model allowlist and normalized usage/cost audit |
+| Direct shell command APIs bypass the model loop | Unreviewed command execution | Separate permission, workspace confinement, audit, and default deny |
+| Trace or memory content captures secrets | Sensitive-data disclosure | Redaction, retention controls, scoped access, and content-minimizing telemetry |
+| AWS quotas or regional limits are exhausted | Provisioning or invocation failure | Deployment preflight, saturation metrics, capacity alerts, and documented quota requests |
 | Provider-specific events break clients | UI/protocol regressions | Normalize before encoding; common conformance and golden-stream tests |
 | SDK upgrades introduce unknown message types | Missing output or false completion | Pinned versions, compatibility fixtures, unknown-event metrics, terminal-event invariants |
 | Capability differences are hidden | Misconfigured or silently degraded agents | Capability registry and save-time validation in UI and API |
@@ -514,9 +721,27 @@ agentic SDK choice, while #2109 concerns an optional AWS-managed backend.
 
 ### AWS
 
+- [Amazon Bedrock AgentCore overview](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)
+- [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html)
+- [Get started with AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-get-started.html)
 - [AgentCore Harness versus Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-vs-runtime.html)
+- [AgentCore Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html)
+- [AgentCore Harness environment](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-environment.html)
+- [AgentCore Harness models](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-models.html)
+- [AgentCore Harness memory](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-memory.html)
+- [AgentCore Harness versioning and endpoints](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-versioning.html)
 - [How AgentCore Runtime works](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)
 - [AgentCore Runtime lifecycle settings](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-lifecycle-settings.html)
+- [AgentCore Runtime OAuth](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html)
+- [AgentCore on-behalf-of token exchange](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/on-behalf-of-token-exchange.html)
+- [AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html)
+- [AgentCore Policy](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html)
+- [AgentCore IAM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-iam.html)
+- [AgentCore resource-based policies](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/resource-based-policies.html)
+- [AgentCore observability](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-get-started.html)
+- [AgentCore telemetry model](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-telemetry.html)
+- [AgentCore quotas](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/bedrock-agentcore-limits.html)
+- [AgentCore release notes](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/release-notes.html)
 
-**Research date**: 2026-08-02. External product behavior must be revalidated during
+**Research date**: 2026-08-03. External product behavior must be revalidated during
 implementation because both Claude Agent SDK and AgentCore are actively evolving.

--- a/docs/docs/specs/2026-08-02-dynamic-agent-multi-harness/spec.md
+++ b/docs/docs/specs/2026-08-02-dynamic-agent-multi-harness/spec.md
@@ -1,0 +1,308 @@
+---
+sidebar_position: 2
+sidebar_label: Specification
+title: "Dynamic Agent Multi-Harness Support"
+---
+
+# Feature Specification: Dynamic Agent Multi-Harness Support
+
+**Feature Branch**: `prebuild/feat/dynamic-agent-multi-harness`
+
+**Created**: 2026-08-02
+
+**Status**: Draft
+
+**Input**: User description: "Support multiple harnesses for Dynamic Agents, including LangChain DeepAgents, Claude Agent SDK, and Amazon Bedrock AgentCore as optional per-agent choices."
+
+## Overview
+
+Dynamic Agents currently execute through one agentic harness. This feature lets an
+administrator select a supported harness for each agent while preserving the current
+DeepAgents behavior as the default.
+
+The initial harness choices are:
+
+- **DeepAgents** — existing default behavior.
+- **Claude Agent SDK** — self-hosted agent loop using Anthropic's supported SDK contract.
+- **Amazon Bedrock AgentCore Harness** — AWS-managed agent loop running on AgentCore Runtime.
+
+Harness selection and execution placement are separate concepts. A harness determines
+how an agent plans, calls tools, manages short-term context, and reports progress. An
+execution provider determines where the agent is hosted and how its lifecycle is
+managed.
+
+The platform presents a consistent Dynamic Agents experience across supported choices:
+
+- Agent configuration and access control
+- Conversation start, follow-up, resume, and cancellation
+- MCP tool access using the caller's delegated identity
+- Streaming text, tool, subagent, approval, usage, completion, and error events
+- AgentOps status, traces, usage, and diagnostics
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Select a Harness Per Agent (Priority: P1)
+
+As a platform administrator, I want to choose a supported harness for each Dynamic
+Agent so that teams can use the execution behavior appropriate for their workload
+without changing the rest of the CAIPE deployment.
+
+**Why this priority**: Per-agent selection is the core capability. Without it, adding
+another SDK only creates a deployment-wide fork and does not satisfy multi-harness
+support.
+
+**Independent Test**: Create one agent for each enabled harness, start a conversation
+with each agent, and verify that the selected harness executes while the same Dynamic
+Agents entry points and access controls remain in effect.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing agent without an explicit harness selection, **When** it is loaded after the feature is enabled, **Then** it continues to use DeepAgents with no required migration.
+2. **Given** multiple harnesses are enabled, **When** an administrator creates or edits an agent, **Then** the administrator can select one supported harness for that agent.
+3. **Given** an agent has a valid harness selection, **When** a user starts a conversation, **Then** only that harness executes the agent run.
+4. **Given** an agent configuration names an unknown, disabled, or unavailable harness, **When** the configuration is saved or invoked, **Then** the system rejects it with an actionable error and does not silently substitute another harness.
+5. **Given** a deployment contains agents using different harnesses, **When** those agents are invoked concurrently, **Then** each agent continues to use its own configured harness.
+
+---
+
+### User Story 2 - Run Claude Agent SDK Agents (Priority: P1)
+
+As a CAIPE operator, I want Claude Agent SDK to be a supported Dynamic Agent harness
+so that teams can use Claude's agent loop, tools, sessions, hooks, and subagents in the
+general-purpose agent platform.
+
+**Why this priority**: Claude Agent SDK exercises option construction, MCP integration,
+hooks, session handling, streaming, and subagent reporting. It validates the common
+contract before a remote managed runtime is introduced.
+
+**Independent Test**: Configure a Claude Agent SDK agent with a system prompt, allowed
+MCP tools, and a resumable conversation. Verify text streaming, tool activity, session
+continuity, usage reporting, and cancellation through the standard Dynamic Agents API.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Claude Agent SDK agent configuration, **When** a user sends a message, **Then** the SDK runs with only the configured tools, model, instructions, and skills.
+2. **Given** the Claude agent calls an MCP tool, **When** the tool request is issued, **Then** it carries the authorized caller context required by CAIPE's downstream policy enforcement.
+3. **Given** the SDK emits text, tool, usage, session, or subagent activity, **When** Dynamic Agents streams the run, **Then** each activity is represented through the platform's common event vocabulary.
+4. **Given** a user sends a follow-up message, **When** the native Claude session remains available, **Then** the conversation resumes with its prior context.
+5. **Given** the native Claude session is missing or cannot be resumed, **When** the user sends a normal follow-up, **Then** the system applies the documented recovery policy and clearly reports whether it recovered with a new session or requires user action.
+6. **Given** a Claude built-in tool can access files or execute commands, **When** the tool is considered for execution, **Then** workspace isolation and CAIPE authorization policy are enforced before the operation is allowed.
+
+---
+
+### User Story 3 - Run an Agent with AgentCore Harness (Priority: P2)
+
+As an AWS platform administrator, I want to run selected Dynamic Agents through
+AgentCore Harness so that those agents can use AWS-managed isolation, scaling,
+sessions, memory options, identity, and observability.
+
+**Why this priority**: AgentCore provides the requested managed execution option, but
+it depends on the common harness contract and introduces asynchronous cloud-resource
+lifecycle management.
+
+**Independent Test**: Create an AgentCore-backed agent, wait for it to become ready,
+invoke it through Dynamic Agents, continue the conversation, inspect its operational
+status, and delete it without using the AWS console.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid AWS settings and an AgentCore-compatible agent configuration, **When** an administrator creates the agent, **Then** the platform provisions or reconciles its required managed resources and exposes lifecycle status.
+2. **Given** the managed agent is ready, **When** an authorized user sends a message, **Then** the request is invoked in the correct AgentCore session and its response is streamed through the standard Dynamic Agents surface.
+3. **Given** the managed resource is still being created, updated, deleted, or has failed, **When** a user attempts an incompatible operation, **Then** the platform returns the current state and an actionable retry or remediation message.
+4. **Given** a conversation continues after its AgentCore execution environment is recycled, **When** the same conversation is invoked again, **Then** durable context follows the configured memory policy rather than relying on an expired execution environment.
+5. **Given** an administrator deletes an AgentCore-backed Dynamic Agent, **When** deletion completes, **Then** CAIPE and managed-resource state are reconciled and no new invocations are accepted.
+
+---
+
+### User Story 4 - Receive a Consistent Streaming Experience (Priority: P2)
+
+As a user or client integrator, I want the same observable run lifecycle regardless of
+the selected harness so that the CAIPE UI, Slack, Webex, and API clients do not require
+harness-specific implementations.
+
+**Why this priority**: A harness-specific wire format would spread SDK coupling into
+every client and make each new harness a full-stack rewrite.
+
+**Independent Test**: Run the common streaming conformance suite against each harness
+and verify that supported lifecycle events have the same meaning, ordering guarantees,
+terminal behavior, and protocol encoding.
+
+**Acceptance Scenarios**:
+
+1. **Given** any supported harness produces response text, **When** it is streamed, **Then** clients receive ordered text deltas and one unambiguous terminal outcome.
+2. **Given** a harness executes a tool, **When** tool activity is streamed, **Then** clients receive correlated start and result events without seeing native SDK message objects.
+3. **Given** a harness reports subagent activity, approvals, usage, warnings, or errors, **When** the capability is supported, **Then** clients receive the corresponding common event.
+4. **Given** a harness does not support a requested interaction, **When** the configuration is saved or invoked, **Then** the system returns a capability error instead of silently omitting the behavior.
+5. **Given** a client disconnects during a run, **When** execution is cancelled or allowed to continue according to policy, **Then** the resulting state is observable and a later request does not create an ambiguous duplicate run.
+
+---
+
+### User Story 5 - Configure and Operate Harnesses Safely (Priority: P2)
+
+As a platform operator, I want capability validation, security controls, health status,
+and harness-specific diagnostics so that I can operate mixed-harness deployments
+without weakening CAIPE's existing authorization boundary.
+
+**Why this priority**: The harnesses have different tools, session stores, hooks,
+identity models, and lifecycle behavior. Safe operation requires these differences to
+be explicit.
+
+**Independent Test**: Exercise a matrix of supported and unsupported options, denied
+MCP calls, missing credentials, native runtime failures, and version mismatches; verify
+fail-closed behavior, redacted diagnostics, and audit records.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent uses features unsupported by its selected harness, **When** it is saved, **Then** the UI and API identify every incompatible feature before execution.
+2. **Given** a caller is not authorized to use an agent or tool, **When** the selected harness attempts execution, **Then** work is denied before the protected operation and no fallback identity is substituted.
+3. **Given** a harness credential or remote runtime is unavailable, **When** a run is attempted, **Then** the failure is classified, redacted, traceable, and does not expose secrets.
+4. **Given** an operator views AgentOps, **When** agents use different harnesses, **Then** the operator can identify the harness, execution provider, native binding, lifecycle state, latency, token usage, cost when available, and failure category.
+5. **Given** a harness adapter is upgraded, **When** compatibility tests fail, **Then** the release is blocked before incompatible agent configurations reach production.
+
+### Edge Cases
+
+- An administrator changes the harness while conversations are active. Existing native
+  session bindings must not be interpreted by the new harness; the platform must require
+  a new session or an explicit supported migration.
+- A native session identifier exists but its transcript, managed memory, or execution
+  environment has expired.
+- A stream ends without a native terminal event, emits a terminal event twice, or fails
+  after reporting completion.
+- A tool start has no result because the run is interrupted, cancelled, or the provider
+  loses connectivity.
+- A harness supports a tool name but not the same input, output, permission, or approval
+  semantics as another harness.
+- The selected model or authentication method is incompatible with the selected harness.
+- AgentCore creates a new immutable version while older conversations are still using a
+  previous version.
+- Managed-resource creation succeeds in AWS but CAIPE loses the response, or CAIPE state
+  is saved while AWS provisioning fails.
+- The Claude SDK process exits, stalls, or produces an SDK message type unknown to the
+  installed adapter version.
+- A caller cancels a run at the same time that the harness completes it.
+- A parent agent references a subagent that uses another harness. Cross-harness subagent
+  execution is not assumed unless explicitly supported by a separate routing contract.
+- A deployment disables a harness while persisted agents still reference it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support selecting one harness per Dynamic Agent.
+- **FR-002**: The initial supported harness identifiers MUST include DeepAgents, Claude Agent SDK, and AgentCore Harness.
+- **FR-003**: Existing agent configurations without a harness selection MUST continue to use DeepAgents.
+- **FR-004**: The system MUST distinguish the agent harness from the execution provider and MUST validate their compatibility as a pair.
+- **FR-005**: A single CAIPE deployment MUST be able to run agents configured with different enabled harnesses.
+- **FR-006**: The system MUST reject unknown, disabled, unavailable, or incompatible harness configurations without silently substituting a fallback harness.
+- **FR-007**: The system MUST expose the capabilities and configuration constraints of each enabled harness to both the administration API and UI.
+- **FR-008**: The system MUST validate model, tool, skill, subagent, approval, session, memory, and execution-provider requirements against the selected harness before accepting the configuration.
+- **FR-009**: The system MUST provide a common run-event vocabulary for text, tool activity, subagent activity, approvals or user input, usage, session changes, warnings, completion, cancellation, and failure.
+- **FR-010**: Native harness messages MUST be translated into common run events before custom SSE, AG-UI, A2A, or other client protocol encoding.
+- **FR-011**: Common events MUST preserve correlation identifiers, ordering information, agent identity, native diagnostic metadata when safe, and exactly one terminal outcome.
+- **FR-012**: The existing Dynamic Agents client protocols MUST remain usable without requiring clients to understand native DeepAgents, Claude SDK, or AgentCore event types.
+- **FR-013**: The system MUST support start, follow-up, resume, cancellation, and status operations where the selected harness advertises those capabilities.
+- **FR-014**: When a requested operation is not supported by the selected harness, the system MUST return a stable, actionable capability error.
+- **FR-015**: CAIPE MUST remain the canonical owner of agent configuration, conversation identity, authorization decisions, and normalized audit history.
+- **FR-016**: The system MUST persist a harness binding that associates a CAIPE conversation with the selected harness, execution provider, native session identifier, and compatible agent version.
+- **FR-017**: Native short-term context MUST follow the selected harness's session policy; durable conversation or memory behavior MUST be explicitly configured and observable.
+- **FR-018**: The system MUST prevent a native session binding created by one harness from being resumed by a different harness.
+- **FR-019**: All harnesses MUST enforce authenticated agent access before execution and MUST preserve the caller identity required for downstream MCP authorization.
+- **FR-020**: Harness-level permissions, hooks, sandboxes, or managed identity controls MUST supplement rather than replace CAIPE's boundary and downstream authorization checks.
+- **FR-021**: The system MUST fail closed when caller identity, required credentials, authorization, or secure tool-routing context is unavailable.
+- **FR-022**: Credentials and native provider secrets MUST be referenced through approved credential mechanisms and MUST NOT be stored in reusable agent definitions, events, traces, or logs.
+- **FR-023**: Claude Agent SDK support MUST cover option validation, MCP tools, allowed built-in tools, workspace isolation, streaming, usage, session continuity, subagent activity, cancellation, and errors.
+- **FR-024**: Claude Agent SDK support MUST remain independent of application-specific persistence, ingestion, workspace-layout, and event contracts.
+- **FR-025**: AgentCore support MUST expose asynchronous create, update, ready, failed, and delete lifecycle states.
+- **FR-026**: AgentCore invocation MUST bind each CAIPE conversation to the appropriate managed session and agent version.
+- **FR-027**: AgentCore durable context MUST not rely solely on an ephemeral runtime session.
+- **FR-028**: Operators MUST be able to identify the harness and execution provider for every configured agent and active run.
+- **FR-029**: Operators MUST receive comparable health, latency, usage, cost when available, lifecycle, and error telemetry across harnesses.
+- **FR-030**: Harness-specific diagnostic metadata MUST be retained only when it is safe, bounded, and redacted.
+- **FR-031**: The system MUST provide contract tests that run the same core scenarios against every enabled harness.
+- **FR-032**: The DeepAgents adapter MUST pass the contract suite before DeepAgents-specific runtime coupling is removed from shared request and streaming paths.
+- **FR-033**: The Claude adapter MUST include compatibility tests for the supported Claude Agent SDK version and every native message type mapped by the adapter.
+- **FR-034**: AgentCore reconciliation MUST be idempotent so retries cannot create uncontrolled duplicate managed resources.
+- **FR-035**: Harness selection MUST be preserved by configuration import, export, seed configuration, and read APIs.
+- **FR-036**: The platform MUST document enabled harnesses, execution providers, required credentials, supported capabilities, operational limits, and recovery behavior.
+
+### Key Entities
+
+- **Harness Definition**: A registered harness type, version, availability state,
+  configuration constraints, and capability declaration.
+- **Execution Provider Definition**: A registered hosting target and its supported
+  lifecycle, identity, networking, streaming, and compatibility characteristics.
+- **Agent Harness Selection**: The harness and execution-provider choice attached to a
+  Dynamic Agent configuration.
+- **Harness Capability Set**: The operations and features a harness supports, including
+  tools, skills, subagents, streaming, approvals, cancellation, sessions, and memory.
+- **Harness Binding**: The association between a CAIPE agent or conversation and its
+  native harness resource, session, and compatible version.
+- **Common Run Event**: A harness-neutral representation of observable agent activity.
+- **Managed Resource State**: The desired and observed lifecycle state of an external
+  execution resource such as AgentCore.
+- **Execution Context**: The authenticated caller, agent, conversation, authorization,
+  trace, credential references, and client context supplied to a run.
+
+### Assumptions
+
+- DeepAgents remains the default during this feature's rollout.
+- Claude Agent SDK is the first additional harness because it exercises a second local
+  SDK contract before the platform adds remote managed-resource lifecycle complexity.
+- AgentCore in this specification means AgentCore Harness when selecting the managed
+  orchestration loop; AgentCore Runtime is modeled as an execution provider.
+- CAIPE continues to own the user-facing Dynamic Agents API and protocol encoders.
+- Native harnesses may provide different feature sets. Product parity means explicit
+  capability reporting and consistent semantics for supported features, not pretending
+  unsupported features exist.
+- Existing RBAC, OpenFGA, OBO, Agent Gateway, MCP, audit, and secret-management policies
+  remain authoritative.
+
+### Non-Functional Requirements
+
+- **NFR-001 — Backward compatibility**: Existing DeepAgents configurations and supported client protocols MUST pass their current regression suites without migration.
+- **NFR-002 — Isolation**: A run MUST NOT read another user, conversation, workspace, native session, or managed execution environment unless an explicit authorized sharing feature permits it.
+- **NFR-003 — Reliability**: Common event translation MUST tolerate duplicate, delayed, partial, and unknown native events without producing duplicate terminal outcomes or corrupting conversation state.
+- **NFR-004 — Performance**: Harness-neutral dispatch and event normalization SHOULD add no more than 100 ms p95 server-side overhead to a run, excluding harness startup, model latency, network transit, and managed-resource provisioning.
+- **NFR-005 — Scalability**: Local and remote harnesses MUST respect deployment concurrency and backpressure limits without allowing one harness to exhaust capacity reserved for all others.
+- **NFR-006 — Security**: External SDKs, CLIs, container artifacts, and cloud permissions MUST receive supply-chain and least-privilege review before release.
+- **NFR-007 — Observability**: Every run MUST be traceable from CAIPE request and conversation identifiers to its harness, execution provider, native session, and terminal outcome.
+- **NFR-008 — Operability**: Harness availability and managed lifecycle failures MUST be visible without requiring direct container, database, or cloud-console access for routine diagnosis.
+
+## Out of Scope
+
+- Replacing DeepAgents as the default harness in the initial release.
+- Automatically converting native prompts, checkpoints, transcripts, or memory between
+  harnesses.
+- Guaranteeing identical reasoning, tool selection, token usage, or model output across
+  harnesses.
+- Supporting every possible combination of harness and execution provider.
+- Direct cross-harness subagent composition inside one native agent loop.
+- Replacing A2A as the protocol for independently deployed agent-to-agent communication.
+- Adding application-specific ingestion, snapshot, or content-persistence behavior to
+  the generic harness contract.
+- Adding Google ADK or standalone Strands adapters in the first delivery; the common
+  contract must leave room for them as follow-up work.
+- Supporting Anthropic consumer-account login or consumer rate limits for CAIPE users.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of existing Dynamic Agent configurations without a harness field continue to execute through DeepAgents and pass the existing regression suite.
+- **SC-002**: Administrators can configure and successfully invoke at least one DeepAgents, Claude Agent SDK, and AgentCore Harness agent in the same deployment.
+- **SC-003**: The common conformance suite passes every mandatory supported scenario for all three initial harnesses.
+- **SC-004**: 100% of unknown, disabled, or incompatible harness configurations are rejected before agent execution with a stable error category.
+- **SC-005**: 100% of tested native text, tool, subagent, approval, usage, session, completion, cancellation, and error messages are either mapped to documented common events or explicitly classified as safe ignored diagnostics.
+- **SC-006**: Every completed, failed, interrupted, or cancelled test run produces exactly one common terminal outcome.
+- **SC-007**: 100% of tested MCP calls preserve the authorized caller identity through the selected harness and fail closed when that identity is absent.
+- **SC-008**: No credential values appear in persisted agent definitions, normalized events, audit records, application logs, or exported traces during security tests.
+- **SC-009**: A Claude conversation survives a supported service restart using the configured session persistence policy, or returns the documented recovery outcome when its native session is unavailable.
+- **SC-010**: AgentCore create, update, retry, invoke, and delete reconciliation tests produce no duplicate managed resources.
+- **SC-011**: Operators can trace every test run from CAIPE conversation ID to harness type, execution provider, native binding, usage data when reported, and terminal result.
+- **SC-012**: Harness-neutral dispatch and event normalization remain within the 100 ms p95 overhead budget under the representative integration workload.
+
+## Dependencies and Related Work
+
+- [Issue #2079 — Multiple Agentic Harness SDK Integration](https://github.com/cnoe-io/ai-platform-engineering/issues/2079)
+- [Issue #2109 — Amazon Bedrock AgentCore Integration](https://github.com/cnoe-io/ai-platform-engineering/issues/2109)
+- [Research and architectural decisions](./research.md)


### PR DESCRIPTION
# Description

Adds a Spec Kit feature specification and supporting research for pluggable Dynamic Agent harnesses.

The proposal:

- keeps DeepAgents as the backward-compatible default
- adds Claude Agent SDK as the first additional harness using Anthropic's public SDK contract
- treats AgentCore Harness as a first-class requested managed AWS option
- separates managed AgentCore Harness from custom-framework hosting on AgentCore Runtime
- defines AgentCore lifecycle, version/endpoint, identity, memory, MCP, observability, quota, and rollout decisions
- separates harness selection from execution placement
- defines common event, capability, session, identity, lifecycle, and observability requirements
- documents rollout phases, risks, and the estimated 15–23 engineer-week scope

Related issues:

- Closes no issue
- Relates to #2079
- Relates to #2109

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this PR does not change charts.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests — not applicable; documentation only
- [ ] All new and existing tests pass — CI is running

## Validation

- `git diff --check`
- `npm run build` in `docs/`
- Docusaurus reports only pre-existing broken-anchor warnings on unrelated pages
- Verified the specification, research, PR body, comments, and reviews contain no private implementation or repository references
