### PR TITLE
fix(ui): grant unlinked service account can_use when agent shared with Everyone

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.65 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.66 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.65 -f your-values.yaml'}
+                  {'    --version 0.5.66 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.65 -f your-values.yaml'}
+              {'    --version 0.5.66 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.66"
+version = "0.5.66-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/service-accounts/[id]/scopes/route.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/scopes/route.ts
@@ -10,8 +10,10 @@ import {
 } from "@/lib/rbac/openfga";
 import { logOpenFgaRebacAuditEvent } from "@/lib/rbac/audit";
 import { getBySub, updateScopesSnapshot } from "@/lib/service-accounts";
+import { findAgentVisibilities } from "@/lib/dynamic-agent-visibility";
 import {
   parseScope,
+  refFromObject,
   scopeCheckTuple,
   scopeWriteTuple,
   type ScopeRef,
@@ -143,29 +145,33 @@ async function refreshSnapshot(
     listOpenFgaObjects({ user: subject, relation: "can_call", type: "tool" }),
   ]);
 
+  const agentIds = agentObjects.objects.map(refFromObject);
+  const toolIds = toolObjects.objects.map(refFromObject);
+
+  // Global (Everyone-shared) agents grant the unlinked SA `can_use` via the
+  // agent's visibility, not via an explicit panel scope. Keep those out of the
+  // display snapshot so the snapshot only ever tracks explicit grants — the
+  // panel surfaces global agents separately as read-only "via Everyone" chips.
+  const visibilityById = await findAgentVisibilities(agentIds);
+  const explicitAgentIds = agentIds.filter((ref) => visibilityById.get(ref) !== "global");
+
   // Preserve prior added_by/added_at where we have them; default new entries to
   // the current editor/time.
   const prior = (await getBySub(saSub))?.scopes_snapshot ?? [];
   const priorByKey = new Map(prior.map((s) => [`${s.type}:${s.ref}`, s]));
 
-  const build = (type: "agent" | "tool", objects: string[]): ServiceAccountScope[] =>
-    objects.map((object) => {
-      const ref = object.slice(object.indexOf(":") + 1);
-      const existing = priorByKey.get(`${type}:${ref}`);
-      return (
-        existing ?? {
+  const build = (type: "agent" | "tool", refs: string[]): ServiceAccountScope[] =>
+    refs.map(
+      (ref) =>
+        priorByKey.get(`${type}:${ref}`) ?? {
           type,
           ref,
           added_by: addedByForNew.sub,
           added_at: addedByForNew.at,
-        }
-      );
-    });
+        },
+    );
 
-  const snapshot = [
-    ...build("agent", agentObjects.objects),
-    ...build("tool", toolObjects.objects),
-  ];
+  const snapshot = [...build("agent", explicitAgentIds), ...build("tool", toolIds)];
   await updateScopesSnapshot(saSub, snapshot);
 }
 
@@ -222,6 +228,24 @@ export async function DELETE(request: Request, context: RouteContext) {
   const pre = await authorizeScopeMutation(request, id);
   if ("response" in pre) return pre.response;
   const { actor, scope } = pre;
+
+  // An agent shared with Everyone (global) grants the unlinked SA `can_use`
+  // through the agent's visibility, not through this explicit scope. Removing
+  // it here would delete a tuple the visibility reconcile re-adds on the next
+  // edit/seed — a silent no-op. Refuse it and point the admin at the agent.
+  if (scope.type === "agent") {
+    const visibilityById = await findAgentVisibilities([scope.ref]);
+    if (visibilityById.get(scope.ref) === "global") {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "This agent is shared with Everyone; unlinked access is managed by the agent's visibility. Change the agent's visibility to revoke it.",
+        },
+        { status: 409 },
+      );
+    }
+  }
 
   // FR-016: removal requires can_manage ONLY (already checked) — the editor
   // need NOT hold the scope. No scope-holding check here, by design.

--- a/ui/src/app/api/admin/service-accounts/__tests__/scopes.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/scopes.test.ts
@@ -47,6 +47,11 @@ jest.mock("@/lib/service-accounts", () => ({
   updateScopesSnapshot: (...args: unknown[]) => mockUpdateScopesSnapshot(...args),
 }));
 
+const mockFindAgentVisibilities = jest.fn();
+jest.mock("@/lib/dynamic-agent-visibility", () => ({
+  findAgentVisibilities: (...args: unknown[]) => mockFindAgentVisibilities(...args),
+}));
+
 jest.mock("@/lib/rbac/organization", () => ({
   organizationObjectId: jest.fn().mockReturnValue("organization:caipe"),
 }));
@@ -95,6 +100,8 @@ beforeEach(() => {
   mockListOpenFgaObjects.mockResolvedValue({ objects: [] });
   mockGetBySub.mockResolvedValue({ sa_sub: SA_ID, scopes_snapshot: [] });
   mockUpdateScopesSnapshot.mockResolvedValue(true);
+  // Default: no agent is global.
+  mockFindAgentVisibilities.mockResolvedValue(new Map());
 });
 
 describe("POST .../[id]/scopes (add)", () => {
@@ -224,6 +231,66 @@ describe("DELETE .../[id]/scopes (remove)", () => {
     const res = await DELETE(scopeRequest({ type: "agent", ref: "incident-resolver" }), ctx());
     expect(res.status).toBe(404);
     expect(mockDeleteExactOpenFgaTuples).not.toHaveBeenCalled();
+  });
+
+  it("409 when removing an agent scope whose agent is global (owned by visibility)", async () => {
+    manageableWithHeld(new Set());
+    // The agent is currently shared with Everyone — its unlinked-SA grant is
+    // owned by the agent's visibility, not by an explicit panel scope, so the
+    // panel must refuse to remove it (removing it would silently revert).
+    mockFindAgentVisibilities.mockResolvedValue(new Map([["default", "global"]]));
+
+    const res = await DELETE(scopeRequest({ type: "agent", ref: "default" }), ctx());
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/everyone|global|visibility/i);
+    expect(mockDeleteExactOpenFgaTuples).not.toHaveBeenCalled();
+  });
+
+  it("still removes an agent scope when the agent is NOT global", async () => {
+    manageableWithHeld(new Set());
+    mockFindAgentVisibilities.mockResolvedValue(new Map([["incident-resolver", "team"]]));
+
+    const res = await DELETE(scopeRequest({ type: "agent", ref: "incident-resolver" }), ctx());
+    expect(res.status).toBe(200);
+    expect(mockDeleteExactOpenFgaTuples).toHaveBeenCalledWith([
+      { user: `service_account:${SA_ID}`, relation: "user", object: "agent:incident-resolver" },
+    ]);
+  });
+});
+
+describe("refreshSnapshot self-heal (global agents are visibility-owned)", () => {
+  it("drops agent entries whose agent is global from the rebuilt snapshot", async () => {
+    manageableWithHeld(new Set(["can_call tool:jira/search"]));
+    // The SA currently holds two agent grants in OpenFGA: one global
+    // (default, visibility-owned) and one explicit (incident-resolver).
+    mockListOpenFgaObjects.mockImplementation(
+      async (input: { relation: string; type: string }) => {
+        if (input.type === "agent") {
+          return { objects: ["agent:default", "agent:incident-resolver"] };
+        }
+        return { objects: ["tool:jira/search"] };
+      },
+    );
+    mockFindAgentVisibilities.mockResolvedValue(
+      new Map([
+        ["default", "global"],
+        ["incident-resolver", "team"],
+      ]),
+    );
+    mockGetBySub.mockResolvedValue({ sa_sub: SA_ID, scopes_snapshot: [] });
+
+    const res = await POST(scopeRequest({ type: "tool", ref: "jira/search" }), ctx());
+    expect(res.status).toBe(200);
+
+    // The rebuilt snapshot must NOT contain the global agent; it keeps the
+    // explicit agent and the tool.
+    const written = mockUpdateScopesSnapshot.mock.calls[0][1] as Array<{ type: string; ref: string }>;
+    const keys = written.map((s) => `${s.type}:${s.ref}`);
+    expect(keys).toContain("agent:incident-resolver");
+    expect(keys).toContain("tool:jira/search");
+    expect(keys).not.toContain("agent:default");
   });
 });
 

--- a/ui/src/app/api/admin/service-accounts/unlinked/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/service-accounts/unlinked/__tests__/route.test.ts
@@ -23,8 +23,15 @@ jest.mock("@/lib/auth-config", () => ({
 }));
 
 const mockCheckOpenFgaTuple = jest.fn();
+const mockListOpenFgaObjects = jest.fn();
 jest.mock("@/lib/rbac/openfga", () => ({
   checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+  listOpenFgaObjects: (...args: unknown[]) => mockListOpenFgaObjects(...args),
+}));
+
+const mockFindAgentVisibilities = jest.fn();
+jest.mock("@/lib/dynamic-agent-visibility", () => ({
+  findAgentVisibilities: (...args: unknown[]) => mockFindAgentVisibilities(...args),
 }));
 
 jest.mock("@/lib/rbac/organization", () => ({
@@ -70,6 +77,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   // Default: non-admin. Individual tests override as needed.
   mockIsPlatformAdmin.mockResolvedValue(false);
+  // Default authoritative reads: no agent grants, empty visibility map.
+  mockListOpenFgaObjects.mockResolvedValue({ objects: [] });
+  mockFindAgentVisibilities.mockResolvedValue(new Map());
 });
 
 describe("GET /api/admin/service-accounts/unlinked", () => {
@@ -103,11 +113,23 @@ describe("GET /api/admin/service-accounts/unlinked", () => {
     expect(mockGetUnlinkedServiceAccount).not.toHaveBeenCalled();
   });
 
-  it("200s for org-admin with correct SA payload", async () => {
+  it("200s for org-admin with authoritative scopes tagged by source", async () => {
     mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
     mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
     mockIsPlatformAdmin.mockResolvedValue(true);
     mockGetUnlinkedServiceAccount.mockResolvedValue(ANON_SA_DOC);
+    // Authoritative agent grants come from OpenFGA, not the Mongo snapshot.
+    // `hello-world` is explicitly granted (team-scoped); `default` is global
+    // (auto-granted because it is shared with Everyone).
+    mockListOpenFgaObjects.mockResolvedValue({
+      objects: ["agent:hello-world", "agent:default"],
+    });
+    mockFindAgentVisibilities.mockResolvedValue(
+      new Map([
+        ["hello-world", "team"],
+        ["default", "global"],
+      ]),
+    );
 
     const res = await GET();
     expect(res.status).toBe(200);
@@ -118,9 +140,44 @@ describe("GET /api/admin/service-accounts/unlinked", () => {
     // QUAL-10: sa_sub is no longer in the response — only id/name/scopes
     expect(body.data.sa_sub).toBeUndefined();
     expect(body.data.name).toBe("unlinked");
+    // Agents are tagged: global → "everyone" (locked), otherwise "explicit".
+    // Tools remain explicit. `jira/search` still comes from the snapshot.
+    expect(body.data.scopes).toEqual(
+      expect.arrayContaining([
+        { type: "agent", ref: "hello-world", source: "explicit" },
+        { type: "agent", ref: "default", source: "everyone" },
+        { type: "tool", ref: "jira/search", source: "explicit" },
+      ]),
+    );
+    expect(body.data.scopes).toHaveLength(3);
+    // The OpenFGA read is keyed on the SA's can_use agent objects.
+    expect(mockListOpenFgaObjects).toHaveBeenCalledWith({
+      user: "service_account:anon-sub-abc",
+      relation: "can_use",
+      type: "agent",
+    });
+  });
+
+  it("does not surface a global agent as a removable explicit scope even if it lingers in the snapshot", async () => {
+    mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    mockIsPlatformAdmin.mockResolvedValue(true);
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
+    // Snapshot still carries a stale manual entry for `default` (a global agent).
+    mockGetUnlinkedServiceAccount.mockResolvedValue({
+      ...ANON_SA_DOC,
+      scopes_snapshot: [
+        { type: "agent", ref: "default", added_by: "admin-sub", added_at: new Date() },
+      ],
+    });
+    mockListOpenFgaObjects.mockResolvedValue({ objects: ["agent:default"] });
+    mockFindAgentVisibilities.mockResolvedValue(new Map([["default", "global"]]));
+
+    const res = await GET();
+    const body = await res.json();
+    // `default` appears exactly once, tagged everyone (locked) — never as a
+    // second explicit chip from the stale snapshot.
     expect(body.data.scopes).toEqual([
-      { type: "agent", ref: "hello-world" },
-      { type: "tool", ref: "jira/search" },
+      { type: "agent", ref: "default", source: "everyone" },
     ]);
   });
 

--- a/ui/src/app/api/admin/service-accounts/unlinked/route.ts
+++ b/ui/src/app/api/admin/service-accounts/unlinked/route.ts
@@ -9,9 +9,12 @@
  * org-admin. Mirrors the guard used by admin-tab-gates/route.ts. Bootstrap-
  * admin email is also accepted (break-glass parity).
  *
- * Response shape: { success, data: { id, sa_sub, name, scopes } }
- * where `scopes` is the Mongo display snapshot (cheap read; authoritative
- * scopes are fetched per-SA via the existing /[id] detail route when editing).
+ * Response shape: { success, data: { id, name, scopes } } where each scope is
+ * tagged with a `source`: agent grants for an Everyone-shared (global) agent
+ * are `"everyone"` (owned by the agent's visibility, not removable here);
+ * everything else is `"explicit"` (added via this panel, removable). Agent
+ * grants are read authoritatively from OpenFGA (`can_use`) so auto-grants from
+ * global agents are visible; tools come from the Mongo snapshot.
  *
  * 403 for non-admins. 404 when the unlinked SA has not been bootstrapped yet.
  *
@@ -23,7 +26,9 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-config";
 import { getUnlinkedServiceAccount } from "@/lib/rbac/unlinked-service-account";
 import { isPlatformAdmin } from "@/lib/rbac/platform-admin";
-import type { ScopeRef } from "@/lib/service-account-scopes";
+import { listOpenFgaObjects } from "@/lib/rbac/openfga";
+import { findAgentVisibilities } from "@/lib/dynamic-agent-visibility";
+import { refFromObject, type UnlinkedScope } from "@/lib/service-account-scopes";
 import type { ServiceAccountScope } from "@/types/mongodb";
 
 export async function GET() {
@@ -57,10 +62,28 @@ export async function GET() {
       );
     }
 
-    const scopes: ScopeRef[] = (sa.scopes_snapshot ?? []).map((s: ServiceAccountScope) => ({
-      type: s.type,
-      ref: s.ref,
+    // Agent grants are authoritative in OpenFGA: this surfaces auto-grants
+    // written when an agent is shared with Everyone, which never touch the
+    // Mongo snapshot. Tool grants stay snapshot-driven.
+    const agentObjects = await listOpenFgaObjects({
+      user: `service_account:${sa.sa_sub}`,
+      relation: "can_use",
+      type: "agent",
+    });
+    const agentIds = agentObjects.objects.map(refFromObject);
+    const visibilityById = await findAgentVisibilities(agentIds);
+
+    const agentScopes: UnlinkedScope[] = agentIds.map((ref) => ({
+      type: "agent",
+      ref,
+      source: visibilityById.get(ref) === "global" ? "everyone" : "explicit",
     }));
+
+    const toolScopes: UnlinkedScope[] = (sa.scopes_snapshot ?? [])
+      .filter((s: ServiceAccountScope) => s.type === "tool")
+      .map((s: ServiceAccountScope) => ({ type: "tool", ref: s.ref, source: "explicit" }));
+
+    const scopes: UnlinkedScope[] = [...agentScopes, ...toolScopes];
 
     return NextResponse.json({
       success: true,

--- a/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
+++ b/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
@@ -23,6 +23,7 @@ const mockWriteOpenFgaTuples = jest.fn();
 const mockIsPlatformDefaultAgent = jest.fn();
 const mockGetPlatformDefaultAgentId = jest.fn();
 const mockFilterAgentsByOwnershipScopeForSession = jest.fn();
+const mockResolveUnlinkedServiceAccountSub = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
   class ApiError extends Error {
@@ -110,6 +111,10 @@ jest.mock("@/lib/rbac/agent-ownership-scope", () => ({
     mockFilterAgentsByOwnershipScopeForSession(...args),
 }));
 
+jest.mock("@/lib/rbac/unlinked-service-account", () => ({
+  resolveUnlinkedServiceAccountSub: (...args: unknown[]) => mockResolveUnlinkedServiceAccountSub(...args),
+}));
+
 jest.mock("@/lib/da-proxy", () => ({
   authenticateRequest: (...args: unknown[]) => mockAuthenticateRequest(...args),
   getDynamicAgentsConfig: (...args: unknown[]) => mockGetDynamicAgentsConfig(...args),
@@ -145,6 +150,7 @@ describe("dynamic agents RBAC routes", () => {
     mockIsPlatformDefaultAgent.mockResolvedValue(false);
     mockGetPlatformDefaultAgentId.mockResolvedValue(null);
     mockFilterAgentsByOwnershipScopeForSession.mockImplementation(async (_session, items) => items);
+    mockResolveUnlinkedServiceAccountSub.mockResolvedValue("sa-unlinked-999");
     mockAuthenticateRequest.mockResolvedValue({
       subject: "alice-sub",
       email: "alice@example.com",
@@ -529,6 +535,40 @@ describe("dynamic agents RBAC routes", () => {
         owner_team_slug: "platform",
         owner_team_id: "team-id",
         owner_subject: "alice-sub",
+      }),
+    );
+  });
+
+  it("creating a global agent resolves and grants the unlinked SA sub", async () => {
+    const insertOne = jest.fn();
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(null),
+      insertOne,
+    });
+    // `canManageOrganization` (route.ts) delegates to `requireResourcePermission`,
+    // which resolves successfully by default in beforeEach — i.e. this session
+    // is treated as a platform admin, allowed to create a global agent.
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/dynamic-agents", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Everyone Agent",
+          system_prompt: "Help everyone",
+          model: { id: "gpt-4.1", provider: "openai" },
+          visibility: "global",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockResolveUnlinkedServiceAccountSub).toHaveBeenCalled();
+    expect(mockReconcileAgentRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        globalUserAccess: true,
+        unlinkedServiceAccountSub: "sa-unlinked-999",
       }),
     );
   });
@@ -1293,6 +1333,9 @@ describe("dynamic agents RBAC routes", () => {
         agentId: "agent-1",
         globalUserAccess: false,
         previousGlobalUserAccess: true,
+        // D4S-5378: the demote (delete) path needs the unlinked SA sub too,
+        // so its grant is revoked in lockstep with user:*.
+        unlinkedServiceAccountSub: "sa-unlinked-999",
       }),
     );
   });
@@ -1326,7 +1369,74 @@ describe("dynamic agents RBAC routes", () => {
         agentId: "agent-2",
         globalUserAccess: true,
         previousGlobalUserAccess: false,
+        // D4S-5378: promoting to global also grants the unlinked SA so
+        // Slack/Webex bot callers are treated as "everyone" immediately.
+        unlinkedServiceAccountSub: "sa-unlinked-999",
       }),
+    );
+  });
+
+  it("promoting team → global passes a null unlinked SA sub when it isn't bootstrapped yet", async () => {
+    mockResolveUnlinkedServiceAccountSub.mockResolvedValue(null);
+    const findOneAndUpdate = jest.fn().mockResolvedValue({ _id: "agent-2", visibility: "global" });
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "agent-2",
+        name: "Promote Me",
+        visibility: "team",
+        owner_team_slug: "team-a",
+        allowed_tools: {},
+      }),
+      findOneAndUpdate,
+    });
+    mockIsPlatformDefaultAgent.mockResolvedValue(false);
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/dynamic-agents?id=agent-2", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ visibility: "global" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockReconcileAgentRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent-2",
+        globalUserAccess: true,
+        unlinkedServiceAccountSub: null,
+      }),
+    );
+  });
+
+  it("does not resolve the unlinked SA sub when visibility stays team-scoped", async () => {
+    const findOneAndUpdate = jest.fn().mockResolvedValue({ _id: "agent-3", visibility: "team" });
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "agent-3",
+        name: "Team Agent",
+        visibility: "team",
+        owner_team_slug: "team-a",
+        allowed_tools: {},
+      }),
+      findOneAndUpdate,
+    });
+    mockIsPlatformDefaultAgent.mockResolvedValue(false);
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/dynamic-agents?id=agent-3", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Team Agent Renamed" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockResolveUnlinkedServiceAccountSub).not.toHaveBeenCalled();
+    expect(mockReconcileAgentRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "agent-3", unlinkedServiceAccountSub: null }),
     );
   });
 

--- a/ui/src/app/api/dynamic-agents/route.ts
+++ b/ui/src/app/api/dynamic-agents/route.ts
@@ -30,6 +30,7 @@ agentRowPermissionsOrDefault,
 resolveAgentListPermissions,
 } from "@/lib/rbac/resource-authz";
 import { resolveShareableOwnershipWrite } from "@/lib/rbac/shareable-resource";
+import { resolveUnlinkedServiceAccountSub } from "@/lib/rbac/unlinked-service-account";
 import type {
 DynamicAgentConfig,
 DynamicAgentConfigWithPermissions,
@@ -578,6 +579,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       updated_at: now.toISOString(),
     };
 
+    // Only resolve the unlinked SA sub when it's actually needed — avoids a
+    // Mongo lookup on every non-global agent create.
+    const unlinkedServiceAccountSub =
+      visibility === "global" ? await resolveUnlinkedServiceAccountSub() : null;
+
     await reconcileAgentRelationships({
       agentId,
       previousAllowedTools: {},
@@ -592,6 +598,9 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       // every member without waiting for the list-time repair in
       // available/route.ts. Fresh create has no previous state to revoke.
       globalUserAccess: visibility === "global",
+      // Also grant the unlinked SA `can_use` so callers with no linked user
+      // identity (Slack/Webex bots) are treated as "everyone" too.
+      unlinkedServiceAccountSub,
     });
 
     try {
@@ -774,6 +783,13 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     const finalAllowedTools = (updateData.allowed_tools ??
       agent.allowed_tools ??
       {}) as Record<string, string[]>;
+    // Resolve the unlinked SA sub whenever the wildcard grant is being
+    // written OR revoked — the delete path needs the exact sub too, so we
+    // can't skip resolution just because the agent is being demoted.
+    const unlinkedServiceAccountSub =
+      finalVisibility === "global" || currentVisibility === "global"
+        ? await resolveUnlinkedServiceAccountSub()
+        : null;
     await reconcileAgentRelationships({
       agentId: id,
       previousAllowedTools: allowedToolsFromAgent(agent),
@@ -792,6 +808,10 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       // only an exact 'global' match counts as a previous wildcard grant.
       globalUserAccess: finalVisibility === "global",
       previousGlobalUserAccess: currentVisibility === "global",
+      // Keep the unlinked SA's grant in sync with the same promote/demote
+      // transition so callers with no linked user identity gain/lose
+      // access exactly when "everyone" does.
+      unlinkedServiceAccountSub,
     });
 
     const updated = await collection.findOneAndUpdate(

--- a/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
+++ b/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
@@ -26,7 +26,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from "react";
-import { Bot, Loader2, Plus, Shield, X } from "lucide-react";
+import { Bot, Loader2, Lock, Plus, Shield, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -36,7 +36,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type { ScopeRef } from "@/lib/service-account-scopes";
+import type { ScopeRef, UnlinkedScope } from "@/lib/service-account-scopes";
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -45,7 +45,7 @@ import type { ScopeRef } from "@/lib/service-account-scopes";
 interface UnlinkedSaData {
   id: string;
   name: string;
-  scopes: ScopeRef[];
+  scopes: UnlinkedScope[];
 }
 
 interface GrantableItem {
@@ -247,6 +247,7 @@ export function UnlinkedServiceAccountModal({
                       {sa.scopes.map((scope) => {
                         const isPending =
                           pendingRemove?.type === scope.type && pendingRemove?.ref === scope.ref;
+                        const isEveryone = scope.source === "everyone";
                         return (
                           <li
                             key={`${scope.type}:${scope.ref}`}
@@ -258,7 +259,16 @@ export function UnlinkedServiceAccountModal({
                                 {scope.type}/{scope.ref}
                               </code>
                             </span>
-                            {isAdmin && (
+                            {isEveryone ? (
+                              <span
+                                className="inline-flex shrink-0 items-center gap-1 rounded-full border border-input px-2 py-0.5 text-[11px] text-muted-foreground"
+                                data-testid={`scope-source-everyone-${scope.ref}`}
+                                title="Shared with Everyone. Managed by the agent's visibility — change the agent to revoke."
+                              >
+                                <Lock className="h-3 w-3" />
+                                Everyone
+                              </span>
+                            ) : isAdmin && (
                               isPending ? (
                                 <span className="inline-flex items-center gap-1.5">
                                   <span className="text-xs text-muted-foreground">Remove?</span>

--- a/ui/src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx
+++ b/ui/src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx
@@ -99,6 +99,38 @@ describe("UnlinkedServiceAccountModal", () => {
     expect(screen.getByTestId("scope-tool-jira/search")).toBeInTheDocument();
   });
 
+  it("renders a global (everyone) agent as a locked chip with no remove button", async () => {
+    mockFetch({
+      sa: {
+        success: true,
+        data: {
+          ...ANON_SA,
+          scopes: [
+            { type: "agent", ref: "default", source: "everyone" },
+            { type: "agent", ref: "hello-world", source: "explicit" },
+          ],
+        },
+      },
+    });
+
+    render(<UnlinkedServiceAccountModal open isAdmin onOpenChange={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scope-agent-default")).toBeInTheDocument();
+    });
+
+    // The everyone-sourced agent must NOT expose a remove control...
+    expect(
+      screen.queryByRole("button", { name: /remove agent default/i }),
+    ).not.toBeInTheDocument();
+    // ...but the explicit one still does.
+    expect(
+      screen.getByRole("button", { name: /remove agent hello-world/i }),
+    ).toBeInTheDocument();
+    // And it carries a visible "Everyone" affordance.
+    expect(screen.getByTestId("scope-source-everyone-default")).toBeInTheDocument();
+  });
+
   it("keeps long scope refs from overflowing the list item (min-w-0/shrink-0/truncate)", async () => {
     render(
       <UnlinkedServiceAccountModal open isAdmin onOpenChange={jest.fn()} />,

--- a/ui/src/lib/__tests__/seed-config-default-agent.test.ts
+++ b/ui/src/lib/__tests__/seed-config-default-agent.test.ts
@@ -102,6 +102,7 @@ describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
       previousSharedTeamSlugs: [],
       globalUserAccess: true,
       previousGlobalUserAccess: false,
+      unlinkedServiceAccountSub: null,
       failClosed: false,
     });
   });
@@ -184,6 +185,7 @@ describe("reconcileHelloWorldBootstrapAgent", () => {
       previousSharedTeamSlugs: [],
       globalUserAccess: true,
       previousGlobalUserAccess: true,
+      unlinkedServiceAccountSub: null,
       failClosed: false,
     });
   });

--- a/ui/src/lib/__tests__/seed-config-import-adopt.test.ts
+++ b/ui/src/lib/__tests__/seed-config-import-adopt.test.ts
@@ -45,6 +45,9 @@ jest.mock("@/lib/rbac/workflow-config-rebac", () => ({
   normalizeSharedWithTeamSlugs: jest.fn(async (slugs: string[]) => slugs),
   repairWorkflowConfigTeamSlugRefs: jest.fn(async () => 0),
 }));
+jest.mock("@/lib/rbac/unlinked-service-account", () => ({
+  resolveUnlinkedServiceAccountSub: jest.fn(async () => null),
+}));
 
 import { adoptConfigImportedAgents, cleanupStaleConfigDriven } from "../seed-config";
 

--- a/ui/src/lib/dynamic-agent-visibility.ts
+++ b/ui/src/lib/dynamic-agent-visibility.ts
@@ -1,0 +1,30 @@
+import { getCollection } from "@/lib/mongodb";
+import type { DynamicAgentConfig } from "@/types/dynamic-agent";
+
+const COLLECTION_NAME = "dynamic_agents";
+
+/**
+ * Resolve the current `visibility` of the given agent ids in a single indexed
+ * `$in` query. Agents not present in the collection are omitted from the map
+ * (caller treats a missing entry as "not global").
+ *
+ * Shared by the Unlinked Access resolver and the SA scope snapshot rebuild so
+ * both agree on which grants are owned by an agent's Everyone-share (global)
+ * rather than by an explicit admin scope.
+ */
+export async function findAgentVisibilities(
+  agentIds: string[],
+): Promise<Map<string, DynamicAgentConfig["visibility"]>> {
+  const result = new Map<string, DynamicAgentConfig["visibility"]>();
+  if (agentIds.length === 0) return result;
+
+  const collection = await getCollection<DynamicAgentConfig>(COLLECTION_NAME);
+  const docs = await collection
+    .find({ _id: { $in: agentIds } }, { projection: { _id: 1, visibility: 1 } })
+    .toArray();
+
+  for (const doc of docs) {
+    result.set(doc._id, doc.visibility);
+  }
+  return result;
+}

--- a/ui/src/lib/rbac/__tests__/openfga-agent-tools-unlinked-sa.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-agent-tools-unlinked-sa.test.ts
@@ -1,0 +1,125 @@
+// Unit tests for `buildAgentRelationshipTupleDiff` focused on the
+// `unlinkedServiceAccountSub` plumbing (D4S-5378): when an agent is shared
+// with Everyone, the unlinked service account (used for Slack/Webex
+// callers with no linked user identity) should also gain `can_use`, since
+// the `user:*` wildcard only matches `user:`-typed subjects, never
+// `service_account:` ones.
+
+import { buildAgentRelationshipTupleDiff } from "../openfga-agent-tools";
+
+describe("buildAgentRelationshipTupleDiff: unlinkedServiceAccountSub", () => {
+  const baseInput = {
+    agentId: "agent-test",
+    previousAllowedTools: {},
+    nextAllowedTools: {},
+    ownerSubject: "alice-sub",
+    organizationId: "caipe",
+    ownerTeamSlug: "platform",
+  } as const;
+
+  it("writes the unlinked SA grant alongside user:* when sharing with Everyone", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      ...baseInput,
+      globalUserAccess: true,
+      unlinkedServiceAccountSub: "sa-unlinked-123",
+    });
+
+    expect(diff.writes).toEqual(
+      expect.arrayContaining([
+        { user: "user:*", relation: "user", object: "agent:agent-test" },
+        { user: "service_account:sa-unlinked-123", relation: "user", object: "agent:agent-test" },
+      ]),
+    );
+  });
+
+  it("deletes the unlinked SA grant alongside user:* when demoted from Everyone", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      ...baseInput,
+      globalUserAccess: false,
+      previousGlobalUserAccess: true,
+      unlinkedServiceAccountSub: "sa-unlinked-123",
+    });
+
+    expect(diff.deletes).toEqual(
+      expect.arrayContaining([
+        { user: "user:*", relation: "user", object: "agent:agent-test" },
+        { user: "service_account:sa-unlinked-123", relation: "user", object: "agent:agent-test" },
+      ]),
+    );
+  });
+
+  it("only writes user:* when the unlinked SA sub is null (not bootstrapped)", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      ...baseInput,
+      globalUserAccess: true,
+      unlinkedServiceAccountSub: null,
+    });
+
+    expect(diff.writes).toEqual(
+      expect.arrayContaining([{ user: "user:*", relation: "user", object: "agent:agent-test" }]),
+    );
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ user: expect.stringMatching(/^service_account:/) })]),
+    );
+  });
+
+  it("only writes user:* when unlinkedServiceAccountSub is omitted entirely", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      ...baseInput,
+      globalUserAccess: true,
+    });
+
+    expect(diff.writes).toEqual(
+      expect.arrayContaining([{ user: "user:*", relation: "user", object: "agent:agent-test" }]),
+    );
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ user: expect.stringMatching(/^service_account:/) })]),
+    );
+  });
+
+  it("emits neither user:* nor the unlinked SA grant when never global", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      ...baseInput,
+      globalUserAccess: false,
+      previousGlobalUserAccess: false,
+      unlinkedServiceAccountSub: "sa-unlinked-123",
+    });
+
+    expect(diff.writes).not.toEqual(expect.arrayContaining([expect.objectContaining({ user: "user:*" })]));
+    expect(diff.deletes).not.toEqual(expect.arrayContaining([expect.objectContaining({ user: "user:*" })]));
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ user: expect.stringMatching(/^service_account:/) })]),
+    );
+    expect(diff.deletes).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ user: expect.stringMatching(/^service_account:/) })]),
+    );
+  });
+
+  it("skips a malformed unlinked SA sub without corrupting the rest of the diff", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      ...baseInput,
+      globalUserAccess: true,
+      unlinkedServiceAccountSub: "bad sub with spaces!",
+    });
+
+    expect(diff.writes).toEqual(
+      expect.arrayContaining([{ user: "user:*", relation: "user", object: "agent:agent-test" }]),
+    );
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ user: expect.stringMatching(/^service_account:/) })]),
+    );
+  });
+
+  it("never grants the unlinked SA anything beyond the use-only `user` relation", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      ...baseInput,
+      globalUserAccess: true,
+      unlinkedServiceAccountSub: "sa-unlinked-123",
+    });
+
+    const unlinkedTuples = diff.writes.filter((t) => t.user === "service_account:sa-unlinked-123");
+    expect(unlinkedTuples).toEqual([
+      { user: "service_account:sa-unlinked-123", relation: "user", object: "agent:agent-test" },
+    ]);
+  });
+});

--- a/ui/src/lib/rbac/openfga-agent-tools.ts
+++ b/ui/src/lib/rbac/openfga-agent-tools.ts
@@ -79,6 +79,17 @@ export interface AgentToolTupleDiffInput {
    * everyone-can-use grant. Mirrors `previousOwnerTeamSlug`.
    */
   previousGlobalUserAccess?: boolean;
+  /**
+   * The platform unlinked service account's `sa_sub`, when known. When
+   * `globalUserAccess` is set, we also write
+   * `service_account:<sub> user agent:<id>` so callers with no linked user
+   * identity (Slack/Webex bots routed through the unlinked SA) are treated
+   * as "everyone" too — `user:*` only matches `user:`-typed subjects, never
+   * `service_account:` ones. Pass `null`/`undefined` to skip this grant
+   * (e.g. the unlinked SA isn't bootstrapped yet); the `user:*` grant is
+   * unaffected either way.
+   */
+  unlinkedServiceAccountSub?: string | null;
 }
 
 export interface ReconcileAgentToolTuplesInput extends AgentToolTupleDiffInput {
@@ -241,12 +252,26 @@ export function buildAgentRelationshipTupleDiff(input: AgentToolTupleDiffInput):
       relation: "user",
       object: `agent:${input.agentId}`,
     });
+    if (isValidOpenFgaId(input.unlinkedServiceAccountSub)) {
+      writes.push({
+        user: `service_account:${input.unlinkedServiceAccountSub}`,
+        relation: "user",
+        object: `agent:${input.agentId}`,
+      });
+    }
   } else if (input.previousGlobalUserAccess) {
     deletes.push({
       user: "user:*",
       relation: "user",
       object: `agent:${input.agentId}`,
     });
+    if (isValidOpenFgaId(input.unlinkedServiceAccountSub)) {
+      deletes.push({
+        user: `service_account:${input.unlinkedServiceAccountSub}`,
+        relation: "user",
+        object: `agent:${input.agentId}`,
+      });
+    }
   }
 
   for (const [serverId, tools] of next) {

--- a/ui/src/lib/rbac/unlinked-service-account.ts
+++ b/ui/src/lib/rbac/unlinked-service-account.ts
@@ -256,3 +256,20 @@ export async function getUnlinkedServiceAccount(): Promise<ServiceAccount | null
   const collection = await getCollection<ServiceAccount>("service_accounts");
   return collection.findOne({ is_platform_unlinked: true, status: "active" });
 }
+
+/**
+ * Best-effort lookup of the unlinked SA's `sa_sub`, for callers (e.g. the
+ * dynamic-agents routes) that grant it access to globally-shared agents.
+ * Never throws — returns `null` when the SA isn't bootstrapped yet, MongoDB
+ * is unavailable, or the lookup otherwise fails, so callers can fail open
+ * (skip the grant) instead of blocking the caller's own request.
+ */
+export async function resolveUnlinkedServiceAccountSub(): Promise<string | null> {
+  try {
+    const sa = await getUnlinkedServiceAccount();
+    return sa?.sa_sub ?? null;
+  } catch (error) {
+    console.warn("[unlinked-service-account] failed to resolve sa_sub:", error);
+    return null;
+  }
+}

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -18,6 +18,7 @@ import { BUILTIN_MCP_CREDENTIAL_SOURCES } from "@/lib/rbac/agentgateway-mcp-disc
 import { computeIngestionSourceId, type IngestionSourceIdentity } from "@/lib/ingestion-source-id";
 import { writeOpenFgaTuples, isOpenFgaReconciliationEnabled } from "@/lib/rbac/openfga";
 import { reconcileAgentRelationships } from "@/lib/rbac/openfga-agent-tools";
+import { resolveUnlinkedServiceAccountSub } from "@/lib/rbac/unlinked-service-account";
 import {
 reconcileConfigDrivenLlmModelRelationships,
 reconcileConfigDrivenMcpServerRelationships,
@@ -183,6 +184,7 @@ async function reconcileSeededAgentRelationships(input: {
   previousSharedTeamSlugs?: string[];
   globalUserAccess?: boolean;
   previousGlobalUserAccess?: boolean;
+  unlinkedServiceAccountSub?: string | null;
   logContext: string;
 }): Promise<void> {
   try {
@@ -199,6 +201,7 @@ async function reconcileSeededAgentRelationships(input: {
       previousSharedTeamSlugs: input.previousSharedTeamSlugs ?? [],
       globalUserAccess: input.globalUserAccess === true,
       previousGlobalUserAccess: input.previousGlobalUserAccess === true,
+      unlinkedServiceAccountSub: input.unlinkedServiceAccountSub ?? null,
       failClosed: false,
     });
   } catch (error) {
@@ -216,6 +219,9 @@ async function seedAgents(
 
   const collection =
     await getCollection<DynamicAgentConfig>("dynamic_agents");
+  // Resolve once per seed pass rather than per agent — the sub is the same
+  // for every agent seeded in this call.
+  const unlinkedServiceAccountSub = await resolveUnlinkedServiceAccountSub();
   let count = 0;
 
   for (const agentData of agents) {
@@ -301,6 +307,7 @@ async function seedAgents(
       previousSharedTeamSlugs: normalizeStringArray(existing?.shared_with_teams),
       globalUserAccess: doc.visibility === "global",
       previousGlobalUserAccess: existing?.visibility === "global",
+      unlinkedServiceAccountSub,
       logContext: "config seed",
     });
 
@@ -337,6 +344,7 @@ export async function adoptConfigImportedAgents(
   );
   const adopted: string[] = [];
   const skipped: string[] = [];
+  const unlinkedServiceAccountSub = await resolveUnlinkedServiceAccountSub();
 
   for (const agentId of agentIds) {
     const existing = await collection.findOne({ _id: agentId });
@@ -372,6 +380,7 @@ export async function adoptConfigImportedAgents(
       previousSharedTeamSlugs: normalizeStringArray(existing.shared_with_teams),
       globalUserAccess: nextVisibility === "global",
       previousGlobalUserAccess: existing.visibility === "global",
+      unlinkedServiceAccountSub,
       logContext: "config import adopt",
     });
 
@@ -1023,6 +1032,7 @@ export async function bootstrapDefaultDynamicAgentIfEmpty(): Promise<boolean> {
       previousSharedTeamSlugs: [],
       globalUserAccess: true,
       previousGlobalUserAccess: false,
+      unlinkedServiceAccountSub: await resolveUnlinkedServiceAccountSub(),
       logContext: "bootstrap insert",
     });
   } catch (err) {
@@ -1055,6 +1065,7 @@ export async function reconcileHelloWorldBootstrapAgent(): Promise<boolean> {
     await getCollection<DynamicAgentConfig>("dynamic_agents");
   const now = new Date().toISOString();
   const doc = buildHelloWorldAgentDoc(now);
+  const unlinkedServiceAccountSub = await resolveUnlinkedServiceAccountSub();
 
   const result = await collection.updateOne(
     {
@@ -1092,6 +1103,7 @@ export async function reconcileHelloWorldBootstrapAgent(): Promise<boolean> {
       previousSharedTeamSlugs: [],
       globalUserAccess: true,
       previousGlobalUserAccess: false,
+      unlinkedServiceAccountSub,
       logContext: "bootstrap revision update",
     });
     console.log(
@@ -1114,6 +1126,7 @@ export async function reconcileHelloWorldBootstrapAgent(): Promise<boolean> {
       previousSharedTeamSlugs: normalizeStringArray(existing.shared_with_teams),
       globalUserAccess: existing.visibility === "global",
       previousGlobalUserAccess: existing.visibility === "global",
+      unlinkedServiceAccountSub,
       logContext: "bootstrap self-heal",
     });
   }
@@ -1394,6 +1407,11 @@ export async function reconcileExistingAgentOpenFgaTuples(): Promise<number> {
     .toArray();
 
   const orgId = caipeOrgKey();
+  // Resolved once for the whole sweep. Also doubles as the backfill path
+  // for agents that were made global before this SA grant existed — the
+  // per-agent write below is unconditional on `isGlobal`, not gated on
+  // whether the agent changed, so a restart repairs any missing grant.
+  const unlinkedServiceAccountSub = await resolveUnlinkedServiceAccountSub();
   for (const agent of agents) {
     const agentId = String(agent._id ?? "").trim();
     if (!agentId) continue;
@@ -1415,6 +1433,7 @@ export async function reconcileExistingAgentOpenFgaTuples(): Promise<number> {
       // Sweep stale org-wide chat grants on team agents (including agents
       // demoted from global before reconcile carried delete flags).
       previousGlobalUserAccess: !isGlobal && !retainPlatformDefaultGrant,
+      unlinkedServiceAccountSub,
       failClosed: false,
     });
   }

--- a/ui/src/lib/service-account-scopes.ts
+++ b/ui/src/lib/service-account-scopes.ts
@@ -31,6 +31,27 @@ export interface ScopeRef {
 }
 
 /**
+ * A scope as surfaced by the Unlinked Access resolver, annotated with where the
+ * grant comes from:
+ *  - `"everyone"` — an agent shared with Everyone (global). Owned by the
+ *    agent's visibility, so it is read-only in the panel; changing it means
+ *    editing the agent.
+ *  - `"explicit"` — added directly to the unlinked SA via this panel; removable.
+ */
+export interface UnlinkedScope extends ScopeRef {
+  source: "everyone" | "explicit";
+}
+
+/**
+ * Strip the `type:` prefix from an OpenFGA object id (`agent:default` →
+ * `default`), yielding the scope `ref`. `listOpenFgaObjects` returns full
+ * object ids; scope refs and Mongo snapshots store the bare id.
+ */
+export function refFromObject(object: string): string {
+  return object.slice(object.indexOf(":") + 1);
+}
+
+/**
  * Validate a tool ref. A tool ref is just an OpenFGA-safe `tool:` object id —
  * the create route's job is to reject GENUINELY malformed input, NOT to mandate
  * a single `<server>/<tool>` convention (the tool namespace doesn't follow one).

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.66"
+version = "0.5.66.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- When a dynamic agent's visibility is set to Everyone, the platform writes `user:* user agent:<id>` — but OpenFGA's `user:*` wildcard only matches `user:`-typed subjects, never `service_account:`-typed ones. Slack/Webex messages with no linked identity are dispatched as the platform's unlinked service account (`service_account:<sub>`), so those callers couldn't use a globally-shared agent until an admin manually added it to the unlinked SA's scopes via Admin → Settings → Service Accounts.
- This adds a matching `service_account:<unlinked_sub> user agent:<id>` write/delete alongside every `user:*` write/delete, gated on the same visibility flags, across the create route, update route, and seed/bootstrap reconciliation paths. No OpenFGA model change, no privilege escalation beyond the one unlinked SA on agents explicitly made public, symmetric on demotion back to team-only.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx jest src/lib/rbac/__tests__/openfga-agent-tools-unlinked-sa.test.ts src/app/api/dynamic-agents/__tests__/route-rbac.test.ts src/lib/__tests__/seed-config-default-agent.test.ts src/lib/__tests__/seed-config-import-adopt.test.ts`
- [x] Full UI test suite (no new regressions vs. main)
- [x] End-to-end verified against a local docker stack: toggling an agent to Everyone grants the unlinked SA `can_use` in OpenFGA; demoting back to Team revokes it; a Slack message from an unlinked sender is able to invoke the now-global agent with no manual admin step
- [ ] Second commit on this PR will follow up with a "team" scope type for the unlinked/Forge SA scoping model; end-to-end testing for that change is still pending