### PR TITLE
fix(ui): preserve explicit unlinked-SA agent grants across visibility demotion

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.66 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.67 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.66 -f your-values.yaml'}
+                  {'    --version 0.5.67 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.66 -f your-values.yaml'}
+              {'    --version 0.5.67 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.67"
+version = "0.5.67-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
+++ b/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
@@ -24,6 +24,7 @@ const mockIsPlatformDefaultAgent = jest.fn();
 const mockGetPlatformDefaultAgentId = jest.fn();
 const mockFilterAgentsByOwnershipScopeForSession = jest.fn();
 const mockResolveUnlinkedServiceAccountSub = jest.fn();
+const mockResolveUnlinkedServiceAccountGrantState = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
   class ApiError extends Error {
@@ -113,6 +114,8 @@ jest.mock("@/lib/rbac/agent-ownership-scope", () => ({
 
 jest.mock("@/lib/rbac/unlinked-service-account", () => ({
   resolveUnlinkedServiceAccountSub: (...args: unknown[]) => mockResolveUnlinkedServiceAccountSub(...args),
+  resolveUnlinkedServiceAccountGrantState: (...args: unknown[]) =>
+    mockResolveUnlinkedServiceAccountGrantState(...args),
 }));
 
 jest.mock("@/lib/da-proxy", () => ({
@@ -151,6 +154,10 @@ describe("dynamic agents RBAC routes", () => {
     mockGetPlatformDefaultAgentId.mockResolvedValue(null);
     mockFilterAgentsByOwnershipScopeForSession.mockImplementation(async (_session, items) => items);
     mockResolveUnlinkedServiceAccountSub.mockResolvedValue("sa-unlinked-999");
+    mockResolveUnlinkedServiceAccountGrantState.mockResolvedValue({
+      sub: "sa-unlinked-999",
+      explicitAgentIds: new Set<string>(),
+    });
     mockAuthenticateRequest.mockResolvedValue({
       subject: "alice-sub",
       email: "alice@example.com",
@@ -1377,7 +1384,10 @@ describe("dynamic agents RBAC routes", () => {
   });
 
   it("promoting team → global passes a null unlinked SA sub when it isn't bootstrapped yet", async () => {
-    mockResolveUnlinkedServiceAccountSub.mockResolvedValue(null);
+    mockResolveUnlinkedServiceAccountGrantState.mockResolvedValue({
+      sub: null,
+      explicitAgentIds: new Set<string>(),
+    });
     const findOneAndUpdate = jest.fn().mockResolvedValue({ _id: "agent-2", visibility: "global" });
     mockGetCollection.mockResolvedValue({
       findOne: jest.fn().mockResolvedValue({

--- a/ui/src/app/api/dynamic-agents/route.ts
+++ b/ui/src/app/api/dynamic-agents/route.ts
@@ -30,7 +30,10 @@ agentRowPermissionsOrDefault,
 resolveAgentListPermissions,
 } from "@/lib/rbac/resource-authz";
 import { resolveShareableOwnershipWrite } from "@/lib/rbac/shareable-resource";
-import { resolveUnlinkedServiceAccountSub } from "@/lib/rbac/unlinked-service-account";
+import {
+  resolveUnlinkedServiceAccountSub,
+  resolveUnlinkedServiceAccountGrantState,
+} from "@/lib/rbac/unlinked-service-account";
 import type {
 DynamicAgentConfig,
 DynamicAgentConfigWithPermissions,
@@ -783,13 +786,17 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     const finalAllowedTools = (updateData.allowed_tools ??
       agent.allowed_tools ??
       {}) as Record<string, string[]>;
-    // Resolve the unlinked SA sub whenever the wildcard grant is being
+    // Resolve the unlinked SA grant state whenever the wildcard grant is being
     // written OR revoked — the delete path needs the exact sub too, so we
     // can't skip resolution just because the agent is being demoted.
-    const unlinkedServiceAccountSub =
+    // `explicitAgentIds` lets a `global → team` demote preserve an explicit
+    // admin grant: the admin changed the agent's visibility, not the panel
+    // override, so the unlinked SA keeps `can_use` on an agent it was
+    // explicitly granted.
+    const { sub: unlinkedServiceAccountSub, explicitAgentIds } =
       finalVisibility === "global" || currentVisibility === "global"
-        ? await resolveUnlinkedServiceAccountSub()
-        : null;
+        ? await resolveUnlinkedServiceAccountGrantState()
+        : { sub: null, explicitAgentIds: new Set<string>() };
     await reconcileAgentRelationships({
       agentId: id,
       previousAllowedTools: allowedToolsFromAgent(agent),
@@ -812,6 +819,7 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       // transition so callers with no linked user identity gain/lose
       // access exactly when "everyone" does.
       unlinkedServiceAccountSub,
+      unlinkedGrantIsExplicit: explicitAgentIds.has(id),
     });
 
     const updated = await collection.findOneAndUpdate(

--- a/ui/src/lib/rbac/__tests__/openfga-agent-tools-unlinked-sa.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-agent-tools-unlinked-sa.test.ts
@@ -122,4 +122,79 @@ describe("buildAgentRelationshipTupleDiff: unlinkedServiceAccountSub", () => {
       { user: "service_account:sa-unlinked-123", relation: "user", object: "agent:agent-test" },
     ]);
   });
+
+  describe("explicit admin grants are durable across visibility demotion", () => {
+    it("preserves the unlinked SA grant on demotion when the grant is explicit", () => {
+      const diff = buildAgentRelationshipTupleDiff({
+        ...baseInput,
+        globalUserAccess: false,
+        previousGlobalUserAccess: true,
+        unlinkedServiceAccountSub: "sa-unlinked-123",
+        unlinkedGrantIsExplicit: true,
+      });
+
+      // user:* still revoked (no explicit equivalent), unlinked SA preserved.
+      expect(diff.deletes).toEqual(
+        expect.arrayContaining([{ user: "user:*", relation: "user", object: "agent:agent-test" }]),
+      );
+      expect(diff.deletes).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ user: "service_account:sa-unlinked-123" }),
+        ]),
+      );
+    });
+
+    it("re-asserts (self-heals) an explicit grant for a non-global agent", () => {
+      const diff = buildAgentRelationshipTupleDiff({
+        ...baseInput,
+        globalUserAccess: false,
+        previousGlobalUserAccess: false,
+        unlinkedServiceAccountSub: "sa-unlinked-123",
+        unlinkedGrantIsExplicit: true,
+      });
+
+      expect(diff.writes).toEqual(
+        expect.arrayContaining([
+          { user: "service_account:sa-unlinked-123", relation: "user", object: "agent:agent-test" },
+        ]),
+      );
+      // A non-global agent never writes user:*.
+      expect(diff.writes).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ user: "user:*" })]),
+      );
+    });
+
+    it("still deletes the unlinked SA grant on demotion when NOT explicit (demotion wins)", () => {
+      const diff = buildAgentRelationshipTupleDiff({
+        ...baseInput,
+        globalUserAccess: false,
+        previousGlobalUserAccess: true,
+        unlinkedServiceAccountSub: "sa-unlinked-123",
+        unlinkedGrantIsExplicit: false,
+      });
+
+      expect(diff.deletes).toEqual(
+        expect.arrayContaining([
+          { user: "user:*", relation: "user", object: "agent:agent-test" },
+          { user: "service_account:sa-unlinked-123", relation: "user", object: "agent:agent-test" },
+        ]),
+      );
+    });
+
+    it("does not self-heal an explicit grant when the sub is null", () => {
+      const diff = buildAgentRelationshipTupleDiff({
+        ...baseInput,
+        globalUserAccess: false,
+        previousGlobalUserAccess: false,
+        unlinkedServiceAccountSub: null,
+        unlinkedGrantIsExplicit: true,
+      });
+
+      expect(diff.writes).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ user: expect.stringMatching(/^service_account:/) }),
+        ]),
+      );
+    });
+  });
 });

--- a/ui/src/lib/rbac/openfga-agent-tools.ts
+++ b/ui/src/lib/rbac/openfga-agent-tools.ts
@@ -90,6 +90,16 @@ export interface AgentToolTupleDiffInput {
    * unaffected either way.
    */
   unlinkedServiceAccountSub?: string | null;
+  /**
+   * When `true`, an admin has explicitly granted the unlinked service account
+   * `can_use` on this agent via the Unlinked Access panel. That grant is owned
+   * by the admin, not by the agent's visibility, so we must NOT delete the
+   * `service_account:<sub> user agent:<id>` tuple when visibility leaves
+   * `global` — only the panel's own removal may. The `user:*` wildcard grant is
+   * still deleted on demotion (it has no explicit-grant equivalent). Defaults to
+   * `false`: a demotion with no explicit grant revokes the unlinked SA as before.
+   */
+  unlinkedGrantIsExplicit?: boolean;
 }
 
 export interface ReconcileAgentToolTuplesInput extends AgentToolTupleDiffInput {
@@ -265,13 +275,29 @@ export function buildAgentRelationshipTupleDiff(input: AgentToolTupleDiffInput):
       relation: "user",
       object: `agent:${input.agentId}`,
     });
-    if (isValidOpenFgaId(input.unlinkedServiceAccountSub)) {
+    if (isValidOpenFgaId(input.unlinkedServiceAccountSub) && !input.unlinkedGrantIsExplicit) {
       deletes.push({
         user: `service_account:${input.unlinkedServiceAccountSub}`,
         relation: "user",
         object: `agent:${input.agentId}`,
       });
     }
+  }
+
+  // An explicit admin grant persists independently of visibility. Re-assert it
+  // for non-global agents (global agents already wrote it above) so the
+  // reconcile sweep self-heals a grant that a prior visibility-driven delete
+  // may have removed. Idempotent at the OpenFGA layer.
+  if (
+    !input.globalUserAccess &&
+    input.unlinkedGrantIsExplicit &&
+    isValidOpenFgaId(input.unlinkedServiceAccountSub)
+  ) {
+    writes.push({
+      user: `service_account:${input.unlinkedServiceAccountSub}`,
+      relation: "user",
+      object: `agent:${input.agentId}`,
+    });
   }
 
   for (const [serverId, tools] of next) {

--- a/ui/src/lib/rbac/unlinked-service-account.ts
+++ b/ui/src/lib/rbac/unlinked-service-account.ts
@@ -273,3 +273,34 @@ export async function resolveUnlinkedServiceAccountSub(): Promise<string | null>
     return null;
   }
 }
+
+/**
+ * The unlinked SA's `sa_sub` plus the set of agent ids an admin has EXPLICITLY
+ * granted it via the Unlinked Access panel, read from `scopes_snapshot`.
+ *
+ * An explicit grant is durable: it must survive an agent's visibility leaving
+ * `global` and survive the startup reconcile sweep. Only the panel's own DELETE
+ * may remove it. Callers use `explicitAgentIds` to decide whether a visibility
+ * demotion should delete the unlinked SA's `can_use` tuple — an explicit grant
+ * is owned by the admin, not by the agent's visibility, so it is preserved.
+ *
+ * Never throws — on any failure returns `sub: null` and an empty set so callers
+ * fall open (skip the grant/preserve nothing) instead of blocking the request.
+ */
+export async function resolveUnlinkedServiceAccountGrantState(): Promise<{
+  sub: string | null;
+  explicitAgentIds: Set<string>;
+}> {
+  try {
+    const sa = await getUnlinkedServiceAccount();
+    const explicitAgentIds = new Set(
+      (sa?.scopes_snapshot ?? [])
+        .filter((scope) => scope.type === "agent")
+        .map((scope) => scope.ref),
+    );
+    return { sub: sa?.sa_sub ?? null, explicitAgentIds };
+  } catch (error) {
+    console.warn("[unlinked-service-account] failed to resolve grant state:", error);
+    return { sub: null, explicitAgentIds: new Set() };
+  }
+}

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -18,7 +18,10 @@ import { BUILTIN_MCP_CREDENTIAL_SOURCES } from "@/lib/rbac/agentgateway-mcp-disc
 import { computeIngestionSourceId, type IngestionSourceIdentity } from "@/lib/ingestion-source-id";
 import { writeOpenFgaTuples, isOpenFgaReconciliationEnabled } from "@/lib/rbac/openfga";
 import { reconcileAgentRelationships } from "@/lib/rbac/openfga-agent-tools";
-import { resolveUnlinkedServiceAccountSub } from "@/lib/rbac/unlinked-service-account";
+import {
+  resolveUnlinkedServiceAccountSub,
+  resolveUnlinkedServiceAccountGrantState,
+} from "@/lib/rbac/unlinked-service-account";
 import {
 reconcileConfigDrivenLlmModelRelationships,
 reconcileConfigDrivenMcpServerRelationships,
@@ -1407,11 +1410,13 @@ export async function reconcileExistingAgentOpenFgaTuples(): Promise<number> {
     .toArray();
 
   const orgId = caipeOrgKey();
-  // Resolved once for the whole sweep. Also doubles as the backfill path
-  // for agents that were made global before this SA grant existed — the
-  // per-agent write below is unconditional on `isGlobal`, not gated on
-  // whether the agent changed, so a restart repairs any missing grant.
-  const unlinkedServiceAccountSub = await resolveUnlinkedServiceAccountSub();
+  // Resolved once for the whole sweep. `explicitAgentIds` records the agents an
+  // admin explicitly granted the unlinked SA via the Unlinked Access panel;
+  // those grants are owned by the admin, not by visibility, so the sweep must
+  // re-assert (self-heal) them rather than delete them. For global agents the
+  // sub also drives the everyone-can-use backfill.
+  const { sub: unlinkedServiceAccountSub, explicitAgentIds } =
+    await resolveUnlinkedServiceAccountGrantState();
   for (const agent of agents) {
     const agentId = String(agent._id ?? "").trim();
     if (!agentId) continue;
@@ -1434,6 +1439,10 @@ export async function reconcileExistingAgentOpenFgaTuples(): Promise<number> {
       // demoted from global before reconcile carried delete flags).
       previousGlobalUserAccess: !isGlobal && !retainPlatformDefaultGrant,
       unlinkedServiceAccountSub,
+      // An explicit admin grant survives the sweep: preserve the unlinked SA's
+      // `can_use` tuple for non-global agents the admin granted directly, and
+      // re-assert it if a prior visibility-driven delete removed it.
+      unlinkedGrantIsExplicit: explicitAgentIds.has(agentId),
       failClosed: false,
     });
   }

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.67"
+version = "0.5.67.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Explicit admin grants added through the **Unlinked Access** panel and the
`visibility: global` auto-grant both write the same OpenFGA tuple
(`service_account:<sub> user agent:<id>`). Because the startup reconcile sweep
(`reconcileExistingAgentOpenFgaTuples`) and the `PUT /api/dynamic-agents`
`global → team` demotion path deleted that tuple purely on visibility, they
**clobbered explicit admin grants on every deploy** — silently removing
unlinked-account access that an admin had deliberately added.

This resolves the "who is authoritative" ambiguity between the agent's
visibility and the admin override:

- **Mongo `scopes_snapshot` (`type: agent`) is authoritative for "explicit".**
  A grant is present because an admin added it via the panel.
- The unlinked-SA tuple is deleted **only** when the agent left `global`
  **AND** the agent is **not** an explicit grant.
- The startup sweep now **self-heals** explicit grants: it re-asserts the
  tuple for non-global agents an admin granted directly, so a prior
  visibility-driven delete is repaired.
- `user:*` still revokes on demotion (it has no explicit-grant equivalent).

Behaviour is now deterministic and history-independent: an explicit grant
survives deploys and only the panel's own DELETE removes it. The single
accepted edge case — an agent that was both global **and** explicitly granted,
then demoted, keeps the grant (explicit wins) — matches admin intent.

No OpenFGA model change.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — compiled successfully
- [x] `npx jest openfga-agent-tools-unlinked-sa` — 11/11 pass, incl. new cases:
  - explicit grant preserved on demotion (`user:*` still revoked)
  - explicit grant self-healed for a non-global agent
  - demotion without explicit grant still deletes (demotion wins)
  - no self-heal when the unlinked SA sub is null
- [ ] Deploy to dev via `prebuild/` image and confirm explicitly-added
      unlinked agents survive a restart