### PR TITLE
feat(dynamic-agents): add token streaming, tool display limits, and error handling fixes

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/log_config.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/log_config.py
@@ -14,6 +14,7 @@ from contextvars import ContextVar
 
 # Conversation context for logging - set in route handlers
 conversation_id_var: ContextVar[str] = ContextVar("conversation_id", default="-")
+tool_result_display_limit_var: ContextVar[int | None] = ContextVar("tool_result_display_limit", default=None)
 
 LOG_FORMAT = "%(asctime)s %(levelname)s [dynamic_agents] conv=%(conversation_id)s %(message)s"
 LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
@@ -143,13 +143,38 @@ def create_app() -> FastAPI:
         )
         if limit_val is not None:
             try:
-                token = tool_result_display_limit_var.set(int(limit_val))
-                try:
-                    return await call_next(request)
-                finally:
-                    tool_result_display_limit_var.reset(token)
+                limit_int = int(limit_val)
             except ValueError:
                 logger.info("Ignored invalid tool_result_display_limit header/param: %r", limit_val)
+                return await call_next(request)
+
+            token = tool_result_display_limit_var.set(limit_int)
+            try:
+                response = await call_next(request)
+            except Exception:
+                tool_result_display_limit_var.reset(token)
+                raise
+
+            if hasattr(response, "body_iterator") and response.body_iterator is not None:
+                original_iterator = response.body_iterator
+
+                async def stream_wrapper():
+                    try:
+                        if hasattr(original_iterator, "__aiter__"):
+                            async for chunk in original_iterator:
+                                yield chunk
+                        else:
+                            for chunk in original_iterator:
+                                yield chunk
+                    finally:
+                        tool_result_display_limit_var.reset(token)
+
+                response.body_iterator = stream_wrapper()
+                return response
+
+            tool_result_display_limit_var.reset(token)
+            return response
+
         return await call_next(request)
 
     # Prometheus HTTP metrics middleware (from main). Mounted BEFORE the
@@ -234,9 +259,7 @@ def create_app() -> FastAPI:
                     media_type=CONTENT_TYPE_LATEST,
                 )
         except ImportError:
-            logger.warning(
-                "prometheus_client not installed; /metrics endpoint disabled"
-            )
+            logger.warning("prometheus_client not installed; /metrics endpoint disabled")
 
     return app
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
@@ -8,7 +8,7 @@ import dotenv
 
 dotenv.load_dotenv()  # Ensure .env is in os.environ before any boto3/httpx clients are created
 
-from dynamic_agents.log_config import setup_logging
+from dynamic_agents.log_config import setup_logging, tool_result_display_limit_var
 
 # Setup logging before other imports that trigger cnoe-agent-utils
 logger = setup_logging()
@@ -131,6 +131,20 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    @app.middleware("http")
+    async def set_tool_result_display_limit(request: Request, call_next):
+        limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get("tool_result_display_limit")
+        if limit_val is not None:
+            try:
+                token = tool_result_display_limit_var.set(int(limit_val))
+                try:
+                    return await call_next(request)
+                finally:
+                    tool_result_display_limit_var.reset(token)
+            except ValueError:
+                pass
+        return await call_next(request)
 
     # Prometheus HTTP metrics middleware (from main). Mounted BEFORE the
     # JWT auth middleware so failed-auth and CORS-preflight requests are

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
@@ -24,9 +24,11 @@ def fatal_exit(message: str) -> None:
     os._exit(1)
 
 
+from collections.abc import Awaitable, Callable
+
 # ruff: noqa: E402
 # Imports must be after logging setup to ensure our format is used
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -133,8 +135,12 @@ def create_app() -> FastAPI:
     )
 
     @app.middleware("http")
-    async def set_tool_result_display_limit(request: Request, call_next):
-        limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get("tool_result_display_limit")
+    async def set_tool_result_display_limit(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get(
+            "tool_result_display_limit"
+        )
         if limit_val is not None:
             try:
                 token = tool_result_display_limit_var.set(int(limit_val))
@@ -143,7 +149,7 @@ def create_app() -> FastAPI:
                 finally:
                     tool_result_display_limit_var.reset(token)
             except ValueError:
-                pass
+                logger.info("Ignored invalid tool_result_display_limit header/param: %r", limit_val)
         return await call_next(request)
 
     # Prometheus HTTP metrics middleware (from main). Mounted BEFORE the

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
@@ -250,7 +250,6 @@ def create_app() -> FastAPI:
     if serve_metrics_on_main_port:
         try:
             from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
-            from starlette.responses import Response
 
             @app.get("/metrics", include_in_schema=False)
             async def metrics() -> Response:

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
@@ -611,6 +611,13 @@ class ClientContext(BaseModel):
     """
 
     source: str = Field(..., description="Client identifier, e.g. 'slack', 'webui'")
+    tool_result_display_limit: int | None = Field(
+        None,
+        description=(
+            "Max chars of tool result content to show in the frontend. "
+            "Set to -1 to disable truncation. Defaults to server-side env limit."
+        ),
+    )
 
     model_config = ConfigDict(extra="allow")
 
@@ -656,6 +663,10 @@ class ChatRequest(BaseModel):
             "interrupt_on, subagents, skills, features, backend. "
             "Ignored: ui, name, description, owner_id, visibility, enabled, is_system, config_driven."
         ),
+    )
+    include_usage: bool = Field(
+        True,
+        description="Whether to include token usage metadata in the done SSE stream event payload.",
     )
     workflow_config_id: str | None = Field(
         None,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -289,15 +289,11 @@ async def _generate_sse_events(
         # to fix. Anything else falls through to the generic message.
         cause = e.cause
         if isinstance(cause, LLMConfigError):
-            logger.warning(
-                f"Agent '{agent_config.name}' has no usable LLM config: {cause}"
-            )
+            logger.warning(f"Agent '{agent_config.name}' has no usable LLM config: {cause}")
             for frame in encoder.on_run_error(str(cause)):
                 yield frame
         else:
-            logger.exception(
-                f"Runtime init failed for agent '{agent_config.name}'"
-            )
+            logger.exception(f"Runtime init failed for agent '{agent_config.name}'")
             for frame in encoder.on_run_error(GENERIC_AGENT_ERROR):
                 yield frame
     except Exception:
@@ -342,7 +338,7 @@ async def chat_start_stream(
             try:
                 tool_result_display_limit_var.set(int(limit))
             except (ValueError, TypeError):
-                pass
+                logger.warning("Unexpected type for tool_result_display_limit in validated context: %r", limit)
 
     await require_agent_use_permission(request.agent_id)
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from dynamic_agents.auth.auth import get_user_context
 from dynamic_agents.auth.authz import require_agent_use_permission
 from dynamic_agents.config import get_settings
-from dynamic_agents.log_config import conversation_id_var
+from dynamic_agents.log_config import conversation_id_var, tool_result_display_limit_var
 from dynamic_agents.models import ChatRequest, ClientContext, DynamicAgentConfig, InputFile, UserContext
 from dynamic_agents.services.llm_clients import LLMConfigError
 from dynamic_agents.services.mongo import MongoDBService, get_mongo_service
@@ -335,6 +335,15 @@ async def chat_start_stream(
     # Set conversation context for logging
     conversation_id_var.set(request.conversation_id)
 
+    # Set request-scoped tool result display limit from client_context if specified
+    if request.client_context:
+        limit = getattr(request.client_context, "tool_result_display_limit", None)
+        if limit is not None:
+            try:
+                tool_result_display_limit_var.set(int(limit))
+            except (ValueError, TypeError):
+                pass
+
     await require_agent_use_permission(request.agent_id)
 
     # Get agent config after the runtime policy check passes.
@@ -359,7 +368,7 @@ async def chat_start_stream(
         f"trace_id={request.trace_id or 'auto'}"
     )
 
-    encoder = get_encoder(request.protocol)
+    encoder = get_encoder(request.protocol, include_usage=request.include_usage)
 
     return StreamingResponse(
         _generate_sse_events(

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/llm_clients.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/llm_clients.py
@@ -138,7 +138,9 @@ def get_llm(provider: str, model_id: str) -> BaseChatModel:
 
     resolved_provider, resolved_model = _resolve_llm_defaults(provider, model_id)
 
-    kwargs: dict[str, Any] = {}
+    kwargs: dict[str, Any] = {
+        "stream_usage": True,
+    }
     if resolved_model is not None:
         kwargs["model"] = resolved_model
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/__init__.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/__init__.py
@@ -117,7 +117,7 @@ def get_encoder(protocol: str = "custom", include_usage: bool = True) -> StreamE
     if protocol == "agui":
         from .agui_sse import AGUIStreamEncoder
 
-        return AGUIStreamEncoder()
+        return AGUIStreamEncoder(include_usage=include_usage)
     from .custom_sse import CustomStreamEncoder
 
     return CustomStreamEncoder(include_usage=include_usage)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/__init__.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/__init__.py
@@ -107,11 +107,12 @@ class StreamEncoder(ABC):
 # ═══════════════════════════════════════════════════════════════
 
 
-def get_encoder(protocol: str = "custom") -> StreamEncoder:
+def get_encoder(protocol: str = "custom", include_usage: bool = True) -> StreamEncoder:
     """Create an encoder for the given protocol.
 
     Args:
         protocol: "custom" (old SSE format) or "agui" (AG-UI protocol)
+        include_usage: Whether to include usage_metadata in the stream finish event
     """
     if protocol == "agui":
         from .agui_sse import AGUIStreamEncoder
@@ -119,4 +120,4 @@ def get_encoder(protocol: str = "custom") -> StreamEncoder:
         return AGUIStreamEncoder()
     from .custom_sse import CustomStreamEncoder
 
-    return CustomStreamEncoder()
+    return CustomStreamEncoder(include_usage=include_usage)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/agui_sse.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/agui_sse.py
@@ -83,8 +83,9 @@ class AGUIStreamEncoder(StreamEncoder):
       attribution when concurrent subagent events interleave.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, include_usage: bool = True) -> None:
         self._helper = LangGraphStreamHelper()
+        self.include_usage = include_usage
         self._active_message_ids: dict[str, str | None] = {}
         self._last_emitted_namespace: tuple[str, ...] = ()
         self._run_id: str = ""
@@ -139,18 +140,18 @@ class AGUIStreamEncoder(StreamEncoder):
         return frames
 
     def on_run_finish(self, run_id: str, thread_id: str) -> list[str]:
-        return [
-            _sse_frame(
-                "RUN_FINISHED",
-                {
-                    "type": "RUN_FINISHED",
-                    "runId": run_id,
-                    "threadId": thread_id,
-                    "outcome": "success",
-                    "timestamp": _ts(),
-                },
-            )
-        ]
+        data: dict[str, Any] = {
+            "type": "RUN_FINISHED",
+            "runId": run_id,
+            "threadId": thread_id,
+            "outcome": "success",
+            "timestamp": _ts(),
+        }
+        if self.include_usage:
+            usage = self._helper.get_total_usage()
+            if usage:
+                data["usage"] = usage
+        return [_sse_frame("RUN_FINISHED", data)]
 
     def on_run_error(self, message: str, code: str | None = None) -> list[str]:
         data: dict[str, Any] = {

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/custom_sse.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/custom_sse.py
@@ -63,8 +63,9 @@ class CustomStreamEncoder(StreamEncoder):
     ``chat.py``.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, include_usage: bool = True) -> None:
         self._helper = LangGraphStreamHelper()
+        self.include_usage = include_usage
 
     # ── Core lifecycle ────────────────────────────────────
 
@@ -90,7 +91,9 @@ class CustomStreamEncoder(StreamEncoder):
         return []  # No state to flush in custom format
 
     def on_run_finish(self, run_id: str, thread_id: str) -> list[str]:
-        return [_sse_frame("done", {})]
+        usage = self._helper.get_total_usage() if self.include_usage else {}
+        payload = {"usage_metadata": usage} if usage else {}
+        return [_sse_frame("done", payload)]
 
     def on_run_error(self, message: str, code: str | None = None) -> list[str]:
         return [_sse_frame("error", {"error": message})]
@@ -152,6 +155,9 @@ class CustomStreamEncoder(StreamEncoder):
             return []
 
         msg_chunk, metadata = data
+
+        # Record token usage metadata from message chunk if present
+        self._helper.record_usage(msg_chunk)
 
         if LangGraphStreamHelper.is_summarization_chunk(msg_chunk, metadata):
             return []

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
@@ -27,17 +27,28 @@ Backstage) receive pre-correlated events without duplicating logic.
 """
 
 import logging
+import os
 from typing import Any
+
+from dynamic_agents.log_config import tool_result_display_limit_var
 
 logger = logging.getLogger(__name__)
 
 # Max chars of tool result content to send to the frontend.
 # Larger results are truncated with a "[...N chars]" suffix.
-TOOL_RESULT_DISPLAY_LIMIT = 2000
+# Set to -1 via environment variable to disable truncation completely.
+TOOL_RESULT_DISPLAY_LIMIT = int(os.getenv("TOOL_RESULT_DISPLAY_LIMIT", "2000"))
 
 
-def truncate_tool_result(content: str, limit: int = TOOL_RESULT_DISPLAY_LIMIT) -> str:
+def truncate_tool_result(content: str, limit: int | None = None) -> str:
     """Truncate tool result content for frontend display."""
+    if limit is None:
+        limit = tool_result_display_limit_var.get(None)
+    if limit is None:
+        limit = TOOL_RESULT_DISPLAY_LIMIT
+
+    if limit < 0:
+        return content
     if len(content) <= limit:
         return content
     remaining = len(content) - limit
@@ -60,6 +71,86 @@ class LangGraphStreamHelper:
         # _last_tool_start_pos marks where the last tool_start boundary is in the array.
         self._content_chunks: list[str] = []
         self._last_tool_start_pos: int = 0
+        self._usage_metadata: dict[str, int] = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+
+    def record_usage(self, msg_chunk: Any) -> None:
+        """Safely extract token usage from an AIMessageChunk or response metadata.
+
+        LangChain exposes usage metadata internally via ``input_tokens`` and ``output_tokens``.
+        We normalize these into standard LLM API keys: ``prompt_tokens``, ``completion_tokens``,
+        and ``total_tokens``.
+        """
+        if not msg_chunk:
+            return
+
+        usage = getattr(msg_chunk, "usage_metadata", None)
+        if not usage and hasattr(msg_chunk, "response_metadata"):
+            resp_meta = getattr(msg_chunk, "response_metadata", {}) or {}
+            if isinstance(resp_meta, dict):
+                usage = resp_meta.get("token_usage") or resp_meta.get("usage")
+
+        if not usage:
+            return
+
+        # Extract prompt / input tokens
+        prompt_toks = 0
+        completion_toks = 0
+        total_toks = 0
+        if isinstance(usage, dict):
+            prompt_toks = (
+                usage["prompt_tokens"]
+                if "prompt_tokens" in usage and usage["prompt_tokens"] is not None
+                else usage.get("input_tokens", 0)
+            )
+            completion_toks = (
+                usage["completion_tokens"]
+                if "completion_tokens" in usage and usage["completion_tokens"] is not None
+                else usage.get("output_tokens", 0)
+            )
+            total_toks = usage.get("total_tokens") or 0
+        else:
+            pt = getattr(usage, "prompt_tokens", None)
+            it = getattr(usage, "input_tokens", None)
+            prompt_toks = pt if pt is not None else (it if it is not None else 0)
+
+            ct = getattr(usage, "completion_tokens", None)
+            ot = getattr(usage, "output_tokens", None)
+            completion_toks = ct if ct is not None else (ot if ot is not None else 0)
+
+            total_toks = getattr(usage, "total_tokens", 0) or 0
+
+        if not isinstance(prompt_toks, int):
+            prompt_toks = 0
+        if not isinstance(completion_toks, int):
+            completion_toks = 0
+        if not isinstance(total_toks, int) or total_toks == 0:
+            total_toks = prompt_toks + completion_toks
+
+        # Update running max/sum for stream events
+        # Note: Depending on provider, chunks may emit incremental or cumulative usage.
+        # If chunk total exceeds current accumulated total, treat as cumulative update;
+        # otherwise accumulate.
+        if total_toks >= self._usage_metadata["total_tokens"] and total_toks > 0:
+            self._usage_metadata["prompt_tokens"] = prompt_toks
+            self._usage_metadata["completion_tokens"] = completion_toks
+            self._usage_metadata["total_tokens"] = total_toks
+        elif prompt_toks > 0 or completion_toks > 0:
+            self._usage_metadata["prompt_tokens"] += prompt_toks
+            self._usage_metadata["completion_tokens"] += completion_toks
+            self._usage_metadata["total_tokens"] += prompt_toks + completion_toks
+
+    def get_total_usage(self) -> dict[str, int]:
+        """Return accumulated token usage dictionary using standard LLM API fields.
+
+        Returns empty dict if total_tokens is 0.
+        """
+        if self._usage_metadata["total_tokens"] <= 0:
+            return {}
+        return dict(self._usage_metadata)
 
     # ── Stateful methods ──────────────────────────────────
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
@@ -34,10 +34,17 @@ from dynamic_agents.log_config import tool_result_display_limit_var
 
 logger = logging.getLogger(__name__)
 
-# Max chars of tool result content to send to the frontend.
-# Larger results are truncated with a "[...N chars]" suffix.
-# Set to -1 via environment variable to disable truncation completely.
-TOOL_RESULT_DISPLAY_LIMIT = int(os.getenv("TOOL_RESULT_DISPLAY_LIMIT", "2000"))
+
+def _get_default_limit() -> int:
+    val = os.getenv("TOOL_RESULT_DISPLAY_LIMIT", "2000")
+    try:
+        return int(val)
+    except ValueError:
+        logger.warning("Invalid TOOL_RESULT_DISPLAY_LIMIT env var %r, falling back to 2000.", val)
+        return 2000
+
+
+TOOL_RESULT_DISPLAY_LIMIT = _get_default_limit()
 
 
 def truncate_tool_result(content: str, limit: int | None = None) -> str:

--- a/ai_platform_engineering/dynamic_agents/tests/test_llm_clients_fallback.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_llm_clients_fallback.py
@@ -60,7 +60,7 @@ def test_get_llm_uses_agent_values_when_both_set(monkeypatch):
 
     assert result == "llm"
     assert captured["provider"] == "aws-bedrock"
-    assert captured["kwargs"] == {"model": "claude-sonnet-4-6"}
+    assert captured["kwargs"] == {"model": "claude-sonnet-4-6", "stream_usage": True}
 
 
 def test_get_llm_falls_back_to_env_provider_when_agent_provider_empty(monkeypatch):
@@ -81,7 +81,7 @@ def test_get_llm_falls_back_to_env_provider_when_agent_provider_empty(monkeypatc
 
     assert result == "llm"
     assert captured["provider"] == "aws-bedrock"
-    assert captured["kwargs"] == {"model": "claude-sonnet-4-6"}
+    assert captured["kwargs"] == {"model": "claude-sonnet-4-6", "stream_usage": True}
 
 
 def test_get_llm_skips_model_kwarg_when_agent_model_empty(monkeypatch):
@@ -131,7 +131,7 @@ def test_get_llm_both_empty_falls_back_to_env(monkeypatch):
 
     assert result == "llm"
     assert captured["provider"] == "aws-bedrock"
-    assert captured["kwargs"] == {}
+    assert captured["kwargs"] == {"stream_usage": True}
 
 
 def test_get_llm_raises_actionable_error_when_no_provider_anywhere(monkeypatch):

--- a/ai_platform_engineering/dynamic_agents/tests/test_token_usage_streaming.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_token_usage_streaming.py
@@ -1,0 +1,167 @@
+"""Unit tests for token usage metadata recording and normalization in stream encoders."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from dynamic_agents.services.stream_encoders.custom_sse import CustomStreamEncoder
+from dynamic_agents.services.stream_encoders.langgraph_helpers import LangGraphStreamHelper
+
+
+@dataclass
+class MockMessageChunk:
+    content: str
+    usage_metadata: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] | None = None
+
+
+def test_langgraph_helper_record_usage_langchain_format():
+    """Verify record_usage normalizes LangChain input_tokens/output_tokens to prompt_tokens/completion_tokens."""
+    helper = LangGraphStreamHelper()
+    chunk1 = MockMessageChunk(
+        content="Hello ",
+        usage_metadata={"input_tokens": 100, "output_tokens": 10, "total_tokens": 110},
+    )
+    chunk2 = MockMessageChunk(
+        content="world!",
+        usage_metadata={"input_tokens": 100, "output_tokens": 25, "total_tokens": 125},
+    )
+
+    helper.record_usage(chunk1)
+    helper.record_usage(chunk2)
+
+    usage = helper.get_total_usage()
+    assert usage == {
+        "prompt_tokens": 100,
+        "completion_tokens": 25,
+        "total_tokens": 125,
+    }
+
+
+def test_langgraph_helper_record_usage_openai_format():
+    """Verify record_usage handles standard OpenAI prompt_tokens/completion_tokens directly."""
+    helper = LangGraphStreamHelper()
+    chunk = MockMessageChunk(
+        content="Testing",
+        response_metadata={"token_usage": {"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70}},
+    )
+
+    helper.record_usage(chunk)
+    usage = helper.get_total_usage()
+    assert usage == {
+        "prompt_tokens": 50,
+        "completion_tokens": 20,
+        "total_tokens": 70,
+    }
+
+
+def test_custom_stream_encoder_done_event_with_usage():
+    """Verify CustomStreamEncoder includes usage_metadata in the done event when usage is available."""
+    encoder = CustomStreamEncoder()
+    chunk = MockMessageChunk(
+        content="Sample response",
+        usage_metadata={"input_tokens": 200, "output_tokens": 30, "total_tokens": 230},
+    )
+
+    events = encoder.on_chunk(((), "messages", (chunk, {})))
+    assert len(events) == 1
+    assert "event: content" in events[0]
+
+    finish_events = encoder.on_run_finish("run-123", "thread-456")
+    assert len(finish_events) == 1
+    assert "event: done" in finish_events[0]
+    assert '"usage_metadata": {"prompt_tokens": 200, "completion_tokens": 30, "total_tokens": 230}' in finish_events[0]
+
+
+def test_custom_stream_encoder_done_event_without_usage():
+    """Verify CustomStreamEncoder outputs empty done event payload when no usage is recorded."""
+    encoder = CustomStreamEncoder()
+    chunk = MockMessageChunk(content="No usage info")
+
+    encoder.on_chunk(((), "messages", (chunk, {})))
+    finish_events = encoder.on_run_finish("run-123", "thread-456")
+
+    assert len(finish_events) == 1
+    assert "event: done\ndata: {}\n\n" in finish_events[0]
+
+
+def test_langgraph_helper_record_usage_duplicate_cumulative_chunks():
+    """Verify identical cumulative usage chunks (e.g. final text + finish_reason) do not inflate token counts."""
+    helper = LangGraphStreamHelper()
+    chunk1 = MockMessageChunk(
+        content="Text",
+        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+    )
+    chunk2 = MockMessageChunk(
+        content="",
+        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+    )
+
+    helper.record_usage(chunk1)
+    helper.record_usage(chunk2)
+
+    usage = helper.get_total_usage()
+    assert usage == {
+        "prompt_tokens": 100,
+        "completion_tokens": 20,
+        "total_tokens": 120,
+    }
+
+
+def test_custom_stream_encoder_include_usage_false():
+    """Verify CustomStreamEncoder omits usage metadata when include_usage=False."""
+    encoder = CustomStreamEncoder(include_usage=False)
+    chunk = MockMessageChunk(
+        content="Sample response",
+        usage_metadata={"input_tokens": 200, "output_tokens": 30, "total_tokens": 230},
+    )
+
+    encoder.on_chunk(((), "messages", (chunk, {})))
+    finish_events = encoder.on_run_finish("run-123", "thread-456")
+
+    assert len(finish_events) == 1
+    assert "event: done\ndata: {}\n\n" in finish_events[0]
+
+
+def test_get_encoder_factory_include_usage():
+    """Verify get_encoder factory propagates include_usage parameter."""
+    from dynamic_agents.services.stream_encoders import get_encoder
+
+    enc_with_usage = get_encoder("custom", include_usage=True)
+    assert getattr(enc_with_usage, "include_usage", None) is True
+
+    enc_without_usage = get_encoder("custom", include_usage=False)
+    assert getattr(enc_without_usage, "include_usage", None) is False
+
+
+def test_record_usage_zero_prompt_tokens_cached_response():
+    """Verify prompt_tokens=0 (cached prompt hit) is correctly preserved rather than overwritten by fallbacks."""
+    helper = LangGraphStreamHelper()
+    chunk = MockMessageChunk(
+        content="Cached response",
+        usage_metadata={"prompt_tokens": 0, "completion_tokens": 15, "total_tokens": 15},
+    )
+    helper.record_usage(chunk)
+    usage = helper.get_total_usage()
+    assert usage == {"prompt_tokens": 0, "completion_tokens": 15, "total_tokens": 15}
+
+
+def test_record_usage_invalid_non_integer_tokens():
+    """Verify negative test: non-integer token counts are safely defaulted to 0 without raising exceptions."""
+    helper = LangGraphStreamHelper()
+    chunk = MockMessageChunk(
+        content="Malformed usage",
+        usage_metadata={"prompt_tokens": "not-an-int", "completion_tokens": None, "total_tokens": "abc"},
+    )
+    helper.record_usage(chunk)
+    assert helper.get_total_usage() == {}
+
+
+def test_record_usage_none_chunk():
+    """Verify negative test: None chunk is safely ignored."""
+    helper = LangGraphStreamHelper()
+    helper.record_usage(None)
+    assert helper.get_total_usage() == {}
+
+
+
+

--- a/ai_platform_engineering/dynamic_agents/tests/test_token_usage_streaming.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_token_usage_streaming.py
@@ -163,5 +163,23 @@ def test_record_usage_none_chunk():
     assert helper.get_total_usage() == {}
 
 
+def test_record_usage_object_form_usage():
+    """Verify non-dict usage object (with prompt_tokens/completion_tokens attrs) is extracted correctly."""
 
+    @dataclass
+    class ObjectUsage:
+        prompt_tokens: int
+        completion_tokens: int
+        total_tokens: int
 
+    helper = LangGraphStreamHelper()
+    chunk = MockMessageChunk(
+        content="Object usage",
+        usage_metadata=ObjectUsage(prompt_tokens=40, completion_tokens=10, total_tokens=50),
+    )
+    helper.record_usage(chunk)
+    assert helper.get_total_usage() == {
+        "prompt_tokens": 40,
+        "completion_tokens": 10,
+        "total_tokens": 50,
+    }

--- a/ai_platform_engineering/dynamic_agents/tests/test_tool_result_display_limit.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_tool_result_display_limit.py
@@ -72,8 +72,9 @@ def test_truncate_tool_result_exact_limit_boundary():
 
 @pytest.mark.anyio
 async def test_middleware_valid_header_sets_contextvar():
-    """Verify real middleware sets ContextVar during request and resets after."""
+    """Verify middleware preserves ContextVar during StreamingResponse body iteration and resets after."""
     from fastapi import FastAPI
+    from starlette.responses import StreamingResponse
 
     app = FastAPI()
     captured_limit = None
@@ -85,34 +86,65 @@ async def test_middleware_valid_header_sets_contextvar():
         )
         if limit_val is not None:
             try:
-                token = tool_result_display_limit_var.set(int(limit_val))
-                try:
-                    return await call_next(request)
-                finally:
-                    tool_result_display_limit_var.reset(token)
+                limit_int = int(limit_val)
             except ValueError:
                 import logging
 
                 logging.getLogger("dynamic_agents.main").info(
                     "Ignored invalid tool_result_display_limit header/param: %r", limit_val
                 )
+                return await call_next(request)
+
+            token = tool_result_display_limit_var.set(limit_int)
+            try:
+                response = await call_next(request)
+            except Exception:
+                tool_result_display_limit_var.reset(token)
+                raise
+
+            if hasattr(response, "body_iterator") and response.body_iterator is not None:
+                original_iterator = response.body_iterator
+
+                async def stream_wrapper():
+                    try:
+                        if hasattr(original_iterator, "__aiter__"):
+                            async for chunk in original_iterator:
+                                yield chunk
+                        else:
+                            for chunk in original_iterator:
+                                yield chunk
+                    finally:
+                        tool_result_display_limit_var.reset(token)
+
+                response.body_iterator = stream_wrapper()
+                return response
+
+            tool_result_display_limit_var.reset(token)
+            return response
+
         return await call_next(request)
 
     @app.get("/")
     async def endpoint():
-        nonlocal captured_limit
-        captured_limit = tool_result_display_limit_var.get(None)
-        return PlainTextResponse("ok")
+        async def stream():
+            nonlocal captured_limit
+            # Capture the ContextVar value inside the body iterator during streaming
+            captured_limit = tool_result_display_limit_var.get(None)
+            yield b"streaming chunk"
+
+        return StreamingResponse(stream())
 
     from httpx import ASGITransport, AsyncClient
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         res = await client.get("/", headers={"x-tool-result-display-limit": "150"})
         assert res.status_code == 200
+        assert res.text == "streaming chunk"
         assert captured_limit == 150
 
         res2 = await client.get("/?tool_result_display_limit=500")
         assert res2.status_code == 200
+        assert res2.text == "streaming chunk"
         assert captured_limit == 500
 
     assert tool_result_display_limit_var.get(None) is None
@@ -135,15 +167,40 @@ async def test_middleware_invalid_non_integer_header_logged(caplog):
         )
         if limit_val is not None:
             try:
-                token = tool_result_display_limit_var.set(int(limit_val))
-                try:
-                    return await call_next(request)
-                finally:
-                    tool_result_display_limit_var.reset(token)
+                limit_int = int(limit_val)
             except ValueError:
                 logging.getLogger("dynamic_agents.main").info(
                     "Ignored invalid tool_result_display_limit header/param: %r", limit_val
                 )
+                return await call_next(request)
+
+            token = tool_result_display_limit_var.set(limit_int)
+            try:
+                response = await call_next(request)
+            except Exception:
+                tool_result_display_limit_var.reset(token)
+                raise
+
+            if hasattr(response, "body_iterator") and response.body_iterator is not None:
+                original_iterator = response.body_iterator
+
+                async def stream_wrapper():
+                    try:
+                        if hasattr(original_iterator, "__aiter__"):
+                            async for chunk in original_iterator:
+                                yield chunk
+                        else:
+                            for chunk in original_iterator:
+                                yield chunk
+                    finally:
+                        tool_result_display_limit_var.reset(token)
+
+                response.body_iterator = stream_wrapper()
+                return response
+
+            tool_result_display_limit_var.reset(token)
+            return response
+
         return await call_next(request)
 
     @app.get("/")
@@ -177,3 +234,51 @@ def test_client_context_invalid_type_raises_validation_error():
 
     with pytest.raises(ValidationError):
         ClientContext(source="web", tool_result_display_limit="not-a-number")
+
+
+def test_get_default_limit_invalid_env_var_warning(monkeypatch, caplog):
+    """Verify non-integer TOOL_RESULT_DISPLAY_LIMIT env var logs warning and falls back to 2000."""
+    import logging
+
+    from dynamic_agents.services.stream_encoders.langgraph_helpers import _get_default_limit
+
+    monkeypatch.setenv("TOOL_RESULT_DISPLAY_LIMIT", "invalid_number")
+    with caplog.at_level(logging.WARNING):
+        limit = _get_default_limit()
+    assert limit == 2000
+    assert "Invalid TOOL_RESULT_DISPLAY_LIMIT env var 'invalid_number'" in caplog.text
+
+
+def test_agui_stream_encoder_include_usage_flag():
+    """Verify AGUIStreamEncoder respects include_usage flag."""
+    import json
+
+    from langchain_core.messages import AIMessageChunk
+
+    from dynamic_agents.services.stream_encoders import get_encoder
+    from dynamic_agents.services.stream_encoders.agui_sse import AGUIStreamEncoder
+
+    encoder_with_usage = get_encoder(protocol="agui", include_usage=True)
+    assert isinstance(encoder_with_usage, AGUIStreamEncoder)
+    assert encoder_with_usage.include_usage is True
+
+    encoder_no_usage = get_encoder(protocol="agui", include_usage=False)
+    assert isinstance(encoder_no_usage, AGUIStreamEncoder)
+    assert encoder_no_usage.include_usage is False
+
+    # Record token usage on the underlying helpers
+    msg_chunk = AIMessageChunk(
+        content="test",
+        usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+    )
+    encoder_with_usage._helper.record_usage(msg_chunk)
+    frames = encoder_with_usage.on_run_finish("run-1", "thread-1")
+    assert len(frames) == 1
+    data = json.loads(frames[0].split("data: ")[1].strip())
+    assert data["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+
+    encoder_no_usage._helper.record_usage(msg_chunk)
+    frames_no_usage = encoder_no_usage.on_run_finish("run-1", "thread-1")
+    assert len(frames_no_usage) == 1
+    data_no_usage = json.loads(frames_no_usage[0].split("data: ")[1].strip())
+    assert "usage" not in data_no_usage

--- a/ai_platform_engineering/dynamic_agents/tests/test_tool_result_display_limit.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_tool_result_display_limit.py
@@ -53,69 +53,114 @@ def test_truncate_tool_result_contextvar_override():
         tool_result_display_limit_var.reset(token)
 
 
+def test_truncate_tool_result_zero_limit():
+    """Verify limit = 0 truncates all non-empty text to 0 chars + suffix."""
+    content = "hello world"
+    assert truncate_tool_result(content, limit=0) == "...[11 chars]"
+
+
+def test_truncate_tool_result_empty_content():
+    """Verify empty content string is returned unchanged."""
+    assert truncate_tool_result("") == ""
+
+
+def test_truncate_tool_result_exact_limit_boundary():
+    """Verify len(content) == limit is not truncated (inclusive <= limit boundary)."""
+    content = "a" * 10
+    assert truncate_tool_result(content, limit=10) == content
+
+
 @pytest.mark.anyio
-async def test_middleware_tool_result_display_limit_header():
-    """Verify set_tool_result_display_limit middleware sets and resets ContextVar."""
+async def test_middleware_valid_header_sets_contextvar():
+    """Verify real middleware sets ContextVar during request and resets after."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
     captured_limit = None
 
-    async def mock_call_next(req: Request):
+    @app.middleware("http")
+    async def set_tool_result_display_limit(request: Request, call_next):
+        limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get(
+            "tool_result_display_limit"
+        )
+        if limit_val is not None:
+            try:
+                token = tool_result_display_limit_var.set(int(limit_val))
+                try:
+                    return await call_next(request)
+                finally:
+                    tool_result_display_limit_var.reset(token)
+            except ValueError:
+                import logging
+
+                logging.getLogger("dynamic_agents.main").info(
+                    "Ignored invalid tool_result_display_limit header/param: %r", limit_val
+                )
+        return await call_next(request)
+
+    @app.get("/")
+    async def endpoint():
         nonlocal captured_limit
         captured_limit = tool_result_display_limit_var.get(None)
         return PlainTextResponse("ok")
 
-    request = Request(
-        {
-            "type": "http",
-            "method": "GET",
-            "path": "/",
-            "headers": [(b"x-tool-result-display-limit", b"150")],
-        }
-    )
+    from httpx import ASGITransport, AsyncClient
 
-    limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get("tool_result_display_limit")
-    assert limit_val == "150"
-
-    token = tool_result_display_limit_var.set(int(limit_val))
-    try:
-        res = await mock_call_next(request)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/", headers={"x-tool-result-display-limit": "150"})
         assert res.status_code == 200
         assert captured_limit == 150
-    finally:
-        tool_result_display_limit_var.reset(token)
+
+        res2 = await client.get("/?tool_result_display_limit=500")
+        assert res2.status_code == 200
+        assert captured_limit == 500
 
     assert tool_result_display_limit_var.get(None) is None
 
 
 @pytest.mark.anyio
-async def test_middleware_tool_result_display_limit_query_param():
-    """Verify middleware parses tool_result_display_limit query param."""
-    request = Request(
-        {
-            "type": "http",
-            "method": "GET",
-            "path": "/?tool_result_display_limit=500",
-            "query_string": b"tool_result_display_limit=500",
-            "headers": [],
-        }
-    )
+async def test_middleware_invalid_non_integer_header_logged(caplog):
+    """Verify negative test: malformed non-integer header logs info and leaves ContextVar unset."""
+    import logging
 
-    limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get("tool_result_display_limit")
-    assert limit_val == "500"
+    from fastapi import FastAPI
 
+    app = FastAPI()
     captured_limit = None
 
-    async def mock_call_next(req: Request):
+    @app.middleware("http")
+    async def set_tool_result_display_limit(request: Request, call_next):
+        limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get(
+            "tool_result_display_limit"
+        )
+        if limit_val is not None:
+            try:
+                token = tool_result_display_limit_var.set(int(limit_val))
+                try:
+                    return await call_next(request)
+                finally:
+                    tool_result_display_limit_var.reset(token)
+            except ValueError:
+                logging.getLogger("dynamic_agents.main").info(
+                    "Ignored invalid tool_result_display_limit header/param: %r", limit_val
+                )
+        return await call_next(request)
+
+    @app.get("/")
+    async def endpoint():
         nonlocal captured_limit
         captured_limit = tool_result_display_limit_var.get(None)
         return PlainTextResponse("ok")
 
-    token = tool_result_display_limit_var.set(int(limit_val))
-    try:
-        await mock_call_next(request)
-        assert captured_limit == 500
-    finally:
-        tool_result_display_limit_var.reset(token)
+    from httpx import ASGITransport, AsyncClient
 
+    with caplog.at_level(logging.INFO):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.get("/", headers={"x-tool-result-display-limit": "invalid-string"})
+            assert res.status_code == 200
+            assert captured_limit is None
+
+    assert "Ignored invalid tool_result_display_limit header/param: 'invalid-string'" in caplog.text
     assert tool_result_display_limit_var.get(None) is None
 
 
@@ -126,32 +171,9 @@ def test_client_context_model_field():
     assert getattr(ctx, "tool_result_display_limit", None) == 300
 
 
-@pytest.mark.anyio
-async def test_middleware_invalid_non_integer_header():
-    """Verify negative test: malformed non-integer header does not raise crash and leaves ContextVar unset."""
-    request = Request(
-        {
-            "type": "http",
-            "method": "GET",
-            "path": "/",
-            "headers": [(b"x-tool-result-display-limit", b"invalid-string")],
-        }
-    )
-
-    limit_val = request.headers.get("x-tool-result-display-limit")
-    assert limit_val == "invalid-string"
-
-    # Verify exception is caught and ContextVar remains unchanged
-    with pytest.raises(ValueError):
-        int(limit_val)
-
-    assert tool_result_display_limit_var.get(None) is None
-
-
 def test_client_context_invalid_type_raises_validation_error():
     """Verify negative test: non-integer tool_result_display_limit fails Pydantic validation."""
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
         ClientContext(source="web", tool_result_display_limit="not-a-number")
-

--- a/ai_platform_engineering/dynamic_agents/tests/test_tool_result_display_limit.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_tool_result_display_limit.py
@@ -1,0 +1,157 @@
+"""Unit tests for per-request tool result display limit configuration and truncation."""
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+from dynamic_agents.log_config import tool_result_display_limit_var
+from dynamic_agents.models import ClientContext
+from dynamic_agents.services.stream_encoders.langgraph_helpers import (
+    TOOL_RESULT_DISPLAY_LIMIT,
+    truncate_tool_result,
+)
+
+
+def test_truncate_tool_result_default_limit():
+    """Verify tool results shorter than default limit are untouched, longer are truncated."""
+    short_content = "a" * 100
+    assert truncate_tool_result(short_content) == short_content
+
+    long_content = "a" * (TOOL_RESULT_DISPLAY_LIMIT + 500)
+    truncated = truncate_tool_result(long_content)
+    assert len(truncated) < len(long_content)
+    assert "...[500 chars]" in truncated
+
+
+def test_truncate_tool_result_explicit_limit_arg():
+    """Verify explicit limit parameter overrides defaults."""
+    content = "hello world python"
+    truncated = truncate_tool_result(content, limit=5)
+    assert truncated == "hello...[13 chars]"
+
+
+def test_truncate_tool_result_negative_limit_untruncated():
+    """Verify limit < 0 disables truncation completely."""
+    long_content = "a" * 5000
+    assert truncate_tool_result(long_content, limit=-1) == long_content
+
+    token = tool_result_display_limit_var.set(-1)
+    try:
+        assert truncate_tool_result(long_content) == long_content
+    finally:
+        tool_result_display_limit_var.reset(token)
+
+
+def test_truncate_tool_result_contextvar_override():
+    """Verify ContextVar setting controls truncation when no limit arg is passed."""
+    token = tool_result_display_limit_var.set(10)
+    try:
+        content = "abcdefghijklmnopqrstuvwxyz"
+        truncated = truncate_tool_result(content)
+        assert truncated == "abcdefghij...[16 chars]"
+    finally:
+        tool_result_display_limit_var.reset(token)
+
+
+@pytest.mark.anyio
+async def test_middleware_tool_result_display_limit_header():
+    """Verify set_tool_result_display_limit middleware sets and resets ContextVar."""
+    captured_limit = None
+
+    async def mock_call_next(req: Request):
+        nonlocal captured_limit
+        captured_limit = tool_result_display_limit_var.get(None)
+        return PlainTextResponse("ok")
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"x-tool-result-display-limit", b"150")],
+        }
+    )
+
+    limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get("tool_result_display_limit")
+    assert limit_val == "150"
+
+    token = tool_result_display_limit_var.set(int(limit_val))
+    try:
+        res = await mock_call_next(request)
+        assert res.status_code == 200
+        assert captured_limit == 150
+    finally:
+        tool_result_display_limit_var.reset(token)
+
+    assert tool_result_display_limit_var.get(None) is None
+
+
+@pytest.mark.anyio
+async def test_middleware_tool_result_display_limit_query_param():
+    """Verify middleware parses tool_result_display_limit query param."""
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/?tool_result_display_limit=500",
+            "query_string": b"tool_result_display_limit=500",
+            "headers": [],
+        }
+    )
+
+    limit_val = request.headers.get("x-tool-result-display-limit") or request.query_params.get("tool_result_display_limit")
+    assert limit_val == "500"
+
+    captured_limit = None
+
+    async def mock_call_next(req: Request):
+        nonlocal captured_limit
+        captured_limit = tool_result_display_limit_var.get(None)
+        return PlainTextResponse("ok")
+
+    token = tool_result_display_limit_var.set(int(limit_val))
+    try:
+        await mock_call_next(request)
+        assert captured_limit == 500
+    finally:
+        tool_result_display_limit_var.reset(token)
+
+    assert tool_result_display_limit_var.get(None) is None
+
+
+def test_client_context_model_field():
+    """Verify ClientContext model accepts tool_result_display_limit field."""
+    ctx = ClientContext(source="web", tool_result_display_limit=300)
+    assert ctx.tool_result_display_limit == 300
+    assert getattr(ctx, "tool_result_display_limit", None) == 300
+
+
+@pytest.mark.anyio
+async def test_middleware_invalid_non_integer_header():
+    """Verify negative test: malformed non-integer header does not raise crash and leaves ContextVar unset."""
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"x-tool-result-display-limit", b"invalid-string")],
+        }
+    )
+
+    limit_val = request.headers.get("x-tool-result-display-limit")
+    assert limit_val == "invalid-string"
+
+    # Verify exception is caught and ContextVar remains unchanged
+    with pytest.raises(ValueError):
+        int(limit_val)
+
+    assert tool_result_display_limit_var.get(None) is None
+
+
+def test_client_context_invalid_type_raises_validation_error():
+    """Verify negative test: non-integer tool_result_display_limit fails Pydantic validation."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ClientContext(source="web", tool_result_display_limit="not-a-number")
+


### PR DESCRIPTION
# Description

This PR introduces token usage tracking and tool display limit controls in `dynamic_agents`:
- **Token Usage Streaming**: Extracts and normalizes LangChain/OpenAI token usage from message chunks, emitting `usage_metadata` payloads in SSE `done` events.
- **Tool Result Display Limits**: Supports per-request `tool_result_display_limit` via HTTP headers (`X-Tool-Result-Display-Limit`) and client context models.
- **Error Handling & Middleware**: Replaces silent exception swallowing in middleware and chat routes with structured logging (`logger.info` for raw headers, `logger.warning` for context parsing), type hints `call_next`, and adds comprehensive unit test suites.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
