### PR TITLE
fix(ci): PR comment with prebuild images permission was broken

### DIFF
--- a/.github/scripts/reconcile-prebuild-artifacts.py
+++ b/.github/scripts/reconcile-prebuild-artifacts.py
@@ -59,7 +59,8 @@ def env(name: str) -> str:
 
 
 REPO = env("GITHUB_REPOSITORY")
-TOKEN = env("GITHUB_TOKEN")
+ACTIONS_TOKEN = env("GITHUB_TOKEN")
+COMMENT_TOKEN = env("GITHUB_COMMENT_TOKEN")
 PR_NUMBER = env("PR_NUMBER")
 HEAD_SHA = env("HEAD_SHA")
 MARKER = f"<!-- prebuild-artifacts pr={PR_NUMBER} sha={HEAD_SHA} -->"
@@ -71,12 +72,13 @@ def api(
     path_or_url: str,
     payload: dict[str, Any] | None = None,
     binary: bool = False,
+    token: str = ACTIONS_TOKEN,
 ) -> Any:
     url = path_or_url if path_or_url.startswith("http") else f"{API_ROOT}{path_or_url}"
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
     headers = {
         "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {TOKEN}",
+        "Authorization": f"Bearer {token}",
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": USER_AGENT,
     }
@@ -106,7 +108,7 @@ def download_artifact_archive(artifact_id: Any) -> bytes:
         url,
         headers={
             "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {TOKEN}",
+            "Authorization": f"Bearer {ACTIONS_TOKEN}",
             "X-GitHub-Api-Version": "2022-11-28",
             "User-Agent": USER_AGENT,
         },
@@ -469,6 +471,7 @@ def list_issue_comments() -> list[dict[str, Any]]:
         data = api(
             "GET",
             f"/repos/{REPO}/issues/{PR_NUMBER}/comments?per_page=100&page={page}",
+            token=COMMENT_TOKEN,
         )
         comments.extend(data)
         if len(data) < 100:
@@ -496,6 +499,7 @@ def reconcile_comment(body: str) -> None:
                     "PATCH",
                     f"/repos/{REPO}/issues/comments/{target['id']}",
                     {"body": body},
+                    token=COMMENT_TOKEN,
                 )
                 print(f"Updated managed prebuild comment {target['id']}.")
             else:
@@ -509,7 +513,11 @@ def reconcile_comment(body: str) -> None:
 
         for duplicate in managed[1:]:
             try:
-                api("DELETE", f"/repos/{REPO}/issues/comments/{duplicate['id']}")
+                api(
+                    "DELETE",
+                    f"/repos/{REPO}/issues/comments/{duplicate['id']}",
+                    token=COMMENT_TOKEN,
+                )
                 print(f"Deleted duplicate managed prebuild comment {duplicate['id']}.")
             except ApiError as error:
                 if error.status != 404:
@@ -520,12 +528,17 @@ def reconcile_comment(body: str) -> None:
         "POST",
         f"/repos/{REPO}/issues/{PR_NUMBER}/comments",
         {"body": body},
+        token=COMMENT_TOKEN,
     )
     print(f"Created managed prebuild comment {created['id']}.")
 
 
 def current_pr_head_sha() -> str:
-    pull = api("GET", f"/repos/{REPO}/pulls/{PR_NUMBER}")
+    pull = api(
+        "GET",
+        f"/repos/{REPO}/pulls/{PR_NUMBER}",
+        token=COMMENT_TOKEN,
+    )
     return str(pull.get("head", {}).get("sha", ""))
 
 
@@ -567,6 +580,7 @@ def archive_older_comments() -> None:
             "PATCH",
             f"/repos/{REPO}/issues/comments/{comment['id']}",
             {"body": body},
+            token=COMMENT_TOKEN,
         )
         print(f"Archived older prebuild artifact comment {comment['id']}.")
 

--- a/.github/workflows/prebuild-artifact-comment.yml
+++ b/.github/workflows/prebuild-artifact-comment.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          # Keep the App token on the high-volume Actions API. PR and comment
+          # calls use the explicitly scoped workflow token below.
           permission-actions: read
-          permission-issues: write
-          permission-pull-requests: read
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -39,6 +39,7 @@ jobs:
       - name: Reconcile prebuild artifact comment
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_COMMENT_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.client_payload.pr_number }}
           HEAD_SHA: ${{ github.event.client_payload.head_sha }}
         run: python3 .github/scripts/reconcile-prebuild-artifacts.py

--- a/.github/workflows/prebuild-rag.yml
+++ b/.github/workflows/prebuild-rag.yml
@@ -1,15 +1,12 @@
-name: "[Prebuild][A2A] Supervisor Agent Docker Build and Push"
-description: "Build and push Supervisor Agent Docker image"
+name: "[Prebuild] CAIPE RAG Build and Push"
+description: "Build and push CAIPE RAG Docker image"
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
     paths:
-      - 'build/Dockerfile'
-      - 'ai_platform_engineering/multi_agents/**'
-      - 'ai_platform_engineering/agents/**'
-      - 'ai_platform_engineering/utils/**'
-      - 'ai_platform_engineering/__init__.py'
+      - 'ai_platform_engineering/knowledge_bases/rag/**'
+  workflow_dispatch:
   workflow_call:
     inputs:
       pr_number:
@@ -33,19 +30,16 @@ on:
         required: false
         type: string
         default: ''
-env:
-  IMAGE_NAME: ${{ github.repository_owner }}/prebuild/ai-platform-engineering
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
+  determine-components:
     runs-on: ubuntu-latest
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
@@ -53,10 +47,84 @@ jobs:
         startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
         github.event.action != 'closed'
       )
+    outputs:
+      components: ${{ steps.set-matrix.outputs.components }}
+      should_build: ${{ steps.set-matrix.outputs.should_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        with:
+          base: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+          ref: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
+          filters: |
+            shared:
+              - 'ai_platform_engineering/knowledge_bases/rag/common/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/requirements.txt'
+              - '.github/**'
+            agent-ontology:
+              - 'ai_platform_engineering/knowledge_bases/rag/agent_ontology/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-ontology'
+            server:
+              - 'ai_platform_engineering/knowledge_bases/rag/server/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server'
+            ingestors:
+              - 'ai_platform_engineering/knowledge_bases/rag/ingestors/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors'
+
+      - name: Set matrix based on changes
+        id: set-matrix
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BUILD_ALL: ${{ steps.filter.outputs.shared == 'true' }}
+          CHANGED_AGENT_ONTOLOGY: ${{ steps.filter.outputs.agent-ontology }}
+          CHANGED_SERVER: ${{ steps.filter.outputs.server }}
+          CHANGED_INGESTORS: ${{ steps.filter.outputs.ingestors }}
+        with:
+          script: |
+            const allComponents = ['agent-ontology', 'server', 'ingestors'];
+            const buildAll = process.env.BUILD_ALL === 'true';
+            let selected;
+            if (buildAll) {
+              selected = allComponents;
+            } else {
+              const env = process.env;
+              selected = allComponents.filter(c => {
+                const envKey = 'CHANGED_' + c.toUpperCase().replace(/-/g, '_');
+                return env[envKey] === 'true';
+              });
+            }
+            core.setOutput('components', JSON.stringify(selected));
+            core.setOutput('should_build', String(selected.length > 0));
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: determine-components
+    if: |
+      needs.determine-components.outputs.should_build == 'true' &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
     permissions:
       contents: write
       packages: write
       pull-requests: write
+
+    strategy:
+      matrix:
+        component: ${{ fromJson(needs.determine-components.outputs.components) }}
+      fail-fast: false
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/prebuild/caipe-rag-${{ matrix.component }}
+      BUILD_CTX: ai_platform_engineering/knowledge_bases/rag
+      DOCKERFILE: ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.${{ matrix.component }}
 
     steps:
       - name: 🔒 harden runner
@@ -65,63 +133,58 @@ jobs:
           egress-policy: audit
 
 
+      - name: Free disk space
+        run: |
+          echo "Disk usage before cleanup:"
+          df -h
+
+          # Remove unnecessary packages and files
+          sudo apt-get remove -y '^ghc-*' || true
+          sudo apt-get remove -y '^dotnet-*' || true
+          sudo apt-get remove -y '^llvm-*' || true
+          sudo apt-get remove -y 'php*' || true
+          sudo apt-get remove -y azure-cli google-cloud-cli hhvm google-chrome-stable firefox powershell mono-devel || true
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+
+          # Remove large directories
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+          # Clean Docker system
+          docker system prune -af --volumes || true
+
+          echo "Disk usage after cleanup:"
+          df -h
+
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           ref: ${{ inputs.head_sha || github.ref }}
           fetch-depth: 0
 
-      - name: Check build eligibility
-        id: eligibility
-        shell: bash
-        env:
-          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
-          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
-        run: |
-          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
-          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            BASE="$BASE_SHA"
-          else
-            BASE="origin/${BASE_REF}"
-          fi
-
-          CORE_CHANGED=false
-          if git diff --name-only "$BASE..HEAD" -- \
-              build/Dockerfile \
-              ai_platform_engineering/multi_agents \
-              ai_platform_engineering/utils \
-              pyproject.toml \
-              uv.lock \
-              ai_platform_engineering/__init__.py | grep -q .; then
-            CORE_CHANGED=true
-          fi
-
-          if [[ "$CORE_CHANGED" == "true" || "${{ contains(inputs.head_ref || github.head_ref, 'single-node') }}" == "true" ]]; then
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Docker Buildx
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Compute prebuild tag
-        if: steps.eligibility.outputs.should_build == 'true'
         id: compute_tag
         shell: bash
         env:
-          BRANCH: ${{ inputs.head_ref || github.head_ref }}
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
           BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
           BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
         run: |
+          BRANCH="$HEAD_REF"
           BRANCH_NO_PREFIX="${BRANCH#prebuild/}"
           BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
           git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
@@ -137,40 +200,43 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
           head_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
           head_ref: ${{ inputs.head_ref || github.head_ref }}
-          source: supervisor-agent
+          source: rag
           type: docker
-          name: ai-platform-engineering
-          repository: ghcr.io/${{ env.IMAGE_NAME }}
+          name: caipe-rag-${{ matrix.component }}
+          repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
-          ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
           status: building
           artifact_suffix: start
 
       - name: Extract metadata for Docker
-        if: steps.eligibility.outputs.should_build == 'true'
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ghcr.io/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
       - name: Set up QEMU
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push A2A Docker image
-        if: steps.eligibility.outputs.should_build == 'true'
+      - name: Clean up before build
+        run: |
+          echo "Cleaning up Docker system before build..."
+          docker system prune -f --volumes || true
+          echo "Current disk usage:"
+          df -h
+
+      - name: Build and Push Docker image
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
-          context: .
-          file: ./build/Dockerfile
+          context: ${{ env.BUILD_CTX }}
+          file: ${{ env.DOCKERFILE }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -185,12 +251,12 @@ jobs:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
           head_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
           head_ref: ${{ inputs.head_ref || github.head_ref }}
-          source: supervisor-agent
+          source: rag
           type: docker
-          name: ai-platform-engineering
-          repository: ghcr.io/${{ env.IMAGE_NAME }}
+          name: caipe-rag-${{ matrix.component }}
+          repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
-          ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
           status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
 
@@ -200,9 +266,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        component: ['ingestors', 'agent-ontology', 'server']
+      fail-fast: false
     env:
       OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/ai-platform-engineering
+      PACKAGE_NAME: prebuild/caipe-rag-${{ matrix.component }}
     steps:
       - name: Delete prebuild images for branch
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
# Description

See: https://github.com/cnoe-io/ai-platform-engineering/actions/workflows/prebuild-artifact-comment.yml
which broke since: https://github.com/cnoe-io/ai-platform-engineering/commit/12e4bcb32b614e1eaf55d44d8fc5be1db7c2c635

Also ci-rag has been WRONG since creation. This is due to the PR: https://github.com/cnoe-io/ai-platform-engineering/pull/1728/changes#diff-933031da8cc3d62dbaddb9e110a50315536ee1adc99b9b709775b79b4a27509a. I have no idea why it renamed the wrong file..... hah

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
