### PR TITLE
fix(docs): publish site at caipe.io root

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -29,15 +29,13 @@ const config: Config = {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4
   },
 
-  // Set the production url of your site here
-  url: 'https://cnoe-io.github.io',
-  // Set the /<baseUrl>/ pathname under which your site is served
-  // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/ai-platform-engineering/',
+  // GitHub Pages serves the project from the custom domain root.
+  url: 'https://caipe.io',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'cnoe.io', // Usually your GitHub org/user name.
+  organizationName: 'cnoe-io', // Usually your GitHub org/user name.
   projectName: 'ai-platform-engineering', // Usually your repo name.
 
   clientModules: ['./src/clientModules/mermaidFullscreen.js'],
@@ -64,6 +62,11 @@ const config: Config = {
     [
       '@docusaurus/plugin-client-redirects',
       {
+        // GitHub Pages preserves the old project path when redirecting its
+        // github.io URL to the custom domain. Keep those existing links valid.
+        createRedirects(existingPath: string) {
+          return `/ai-platform-engineering${existingPath}`;
+        },
         redirects: [
           // /docs/index has no real page; redirect to Quick Start
           {from: '/docs/index', to: '/docs/getting-started/quick-start'},

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+caipe.io


### PR DESCRIPTION
# Description

Fix the GitHub Pages deployment for the `caipe.io` custom domain.

The site was built with `url: https://cnoe-io.github.io` and `baseUrl: /ai-platform-engineering/`, but GitHub Pages serves the custom domain at its root. That mismatch caused Docusaurus to show its base URL error banner and generated broken internal asset and navigation paths.

This change:

- sets the canonical URL to `https://caipe.io`
- serves Docusaurus from `/`
- includes the `CNAME` file in the published artifact
- generates compatibility redirects for existing `/ai-platform-engineering/...` links
- corrects the GitHub organization name in the Docusaurus deployment metadata

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Validation

- `npm run typecheck`
- `npm run build`
- verified root-relative asset URLs and canonical metadata in `docs/build/index.html`
- verified `docs/build/CNAME` contains `caipe.io`
- verified legacy project-path redirect pages are generated

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by the production build validation
- [x] All new and existing relevant tests pass
