### PR TITLE
fix(docs): show mobile navigation menu

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -65,6 +65,13 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
 }
 
+/* A backdrop filter creates a containing block for fixed descendants. Disable
+ * it while the mobile sidebar is open so the sidebar fills the viewport. */
+.navbar.navbar-sidebar--show {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 [data-theme='dark'] .navbar {
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }


### PR DESCRIPTION
# Description

Fix the iPhone/mobile navbar sidebar being clipped to the 60px navbar height. The navbar backdrop filter created a containing block for the fixed sidebar, so this disables the filter only while the sidebar is open and lets it fill the viewport.

Validated at a 390x844 viewport by opening and closing the hamburger menu. The sidebar fills the 844px viewport and all navigation links are visible.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by browser verification
- [x] All new and existing relevant tests pass

## Validation

- npm run typecheck
- npm run build
- Browser test at 390x844: open menu, verify full-height sidebar and visible links, close menu